### PR TITLE
Durable approval gates, cost caps, approver scoping, signed webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Each pipeline is a fixed sequence of typed steps. The LLM never chooses the next
 | --------------- | -------------------------------------------------------------------- |
 | `deterministic` | Plain Go — fetch emails, parse PDFs, dedup, route, notify            |
 | `ai`            | LLM inference with a skill template, budget-checked, schema-validated |
-| `approval`      | Operator reviews via Telegram / Slack: approve / edit / reject       |
+| `approval`      | Operator reviews via Telegram: approve / edit / reject                |
 
 ```yaml
 pipelines:
@@ -160,12 +160,16 @@ normalized message JSON into a `schedule: webhook` pipeline that starts with
 ## Governance
 
 - **Token budgets** — per-step / pipeline / day; any breach halts the run immediately.
+- **Cost budgets** — `per_day_cost` / `per_pipeline_cost` cap spend in money, using the same unit as your model rates. Token caps say how much it thought; these answer what it costs.
 - **Human-in-the-loop** — every outbound action requires explicit operator approval.
+- **Durable approval gates** — an open gate is written to SQLite *before* the draft is sent. If the process restarts mid-approval, the next boot records it as `interrupted`, tells the operator the action did **not** run, and leaves it visible to the audit queries. A gate whose outcome is unknown is never treated as an approval.
+- **Approver scoping** — `approvers:` on a step narrows who may decide it to a subset of `allowed_users`. Quorum says *how many*; this says *which ones*. It can only narrow, never widen.
 - **Input sanitization** — operator input is scrubbed for prompt-injection patterns before the LLM.
 - **Output validation** — AI output is checked against the skill's `output_schema` (field types, numeric `min`/`max`, `enum` membership) and rejected if it doesn't conform.
 - **Checked action receipts** — approval decisions can be tied to a payload hash and verified later; see [`docs/action-receipts.md`](docs/action-receipts.md).
 - **Rate limiting** — per-user, per-minute caps on operator interactions.
 - **Channel security** — allowed-user lists + input-length limits enforced at startup; the engine refuses to start without them.
+- **Config validated on boot** — the engine runs the same checks as `draftcat validate` at startup and refuses to start on errors, so a bad config fails at boot rather than mid-pipeline hours later. `DRAFTCAT_SKIP_VALIDATE=1` overrides.
 - **Observability** — opt-in structured JSON spans, one per pipeline and step (duration, status, tokens, cost). Off by default; `observability.spans: true` or `DRAFTCAT_TRACE=1`.
 
 ## State, dedup & triggers
@@ -189,6 +193,22 @@ curl -X POST http://127.0.0.1:8088/hooks/invoice-due-diligence \
 
 The body reaches the pipeline as `{{webhook_body}}` / `{{input}}`; bearer auth is constant-time, and a second trigger while the pipeline is running gets `409`. A webhook only *starts* a pipeline — the approval gate still runs, so an inbound request can never make the LLM fire an outbound action.
 
+**Signed requests.** A bearer token proves only that the caller once saw the token: it does not bind the body, and a captured header replays forever. Set `require_signature: true` to demand a body-bound HMAC receipt as well:
+
+```yaml
+webhook:
+  enabled: true
+  secret_env: DRAFTCAT_WEBHOOK_SECRET
+  require_signature: true
+  max_skew_seconds: 300      # default
+```
+
+```
+X-Draftcat-Signature: t=<unix>,v1=<hex hmac-sha256(t + "." + body)>
+```
+
+Requests outside the skew window are refused, and each signature is spent once (recorded in the dedup table), so a captured request cannot be re-fired. A signature header is verified whenever it is present, even with `require_signature: false` — a signer that breaks should fail loudly rather than be silently ignored.
+
 ## Configuration
 
 ```yaml
@@ -203,22 +223,39 @@ budgets:
   per_step_tokens:     2048
   per_pipeline_tokens: 10000
   per_day_tokens:      100000
+  per_day_cost:        5.00     # money cap, same unit as your model rates (0 = off)
+  per_pipeline_cost:   0.50
 
 observability: {spans: false}   # or DRAFTCAT_TRACE=1
 state:         {path: ./state.db}
 ```
+
+An approval step can narrow who may decide it:
+
+```yaml
+- name: release-payment
+  type: approval
+  channel: telegram
+  quorum: 2                     # how many must approve
+  approvers: [111111, 222222]   # which ones (subset of allowed_users)
+```
+
+Cost caps are enforced *between* calls — a call is refused once spend has already
+reached the cap, so one in-flight call can overshoot by at most a step. Bound
+that with `per_step_tokens`.
 
 Skills are YAML prompt templates in `skills/` with an `output_schema` the engine enforces. With `-tags voice`, a `voice:` block configures the webhook receivers, Dograh endpoints, and pre-call lookup — see [docs/voice.md](docs/voice.md).
 
 ## Commands
 
 ```bash
-draftcat                       # run the engine
+draftcat                       # run the engine (validates config first; refuses to start on errors)
 draftcat validate [--strict]   # lint config + skills
 draftcat test <pipeline>       # dry-run against fixtures/<pipeline>/ (never touches real APIs)
+draftcat audit-verify          # verify signed approval receipts
 ```
 
-Pre-commit hooks (lefthook) run `gofmt`, `go vet`, `go build`, and `go test -short`; pre-push runs `draftcat validate --strict`.
+Pre-commit hooks (lefthook) run `gofmt`, `go vet`, `go build`, `go test -short`, and `golangci-lint` on new code; pre-push runs `draftcat validate`.
 
 ## Voice AI plugin
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 Draftcat runs YAML-defined pipelines that triage email, qualify leads, draft replies, extract data from PDFs, and govern self-hosted voice AI. Every outbound action passes an operator approval gate, every LLM call is budget-checked, and every fetched item is deduped against a SQLite state store. One business per instance, self-hosted, auditable.
 
-> **New in v0.4.0:** approval gates now survive a restart (an interrupted gate is recorded and the operator told the action did *not* run), spend caps in money (`per_day_cost`), per-step `approvers`, body-signed webhooks (`require_signature`), config validated on the boot path, and WhatsApp intake (`whatsapp_intake`).
+> **New in v0.4.0:** approval gates now survive a restart (an interrupted gate is recorded and the operator told the action did *not* run), spend caps in money (`per_day_cost`), per-step `approvers`, body-signed webhooks (`require_signature`), config validated on the boot path with did-you-mean hints, `draftcat runs` to read the audit trail back, and WhatsApp intake (`whatsapp_intake`).
 >
 > **In v0.3.1:** multi-operator quorum approval (`quorum: N`), tamper-evident signed approval receipts (`draftcat audit-verify`), and OTLP + Prometheus exporters. (v0.3.1 is v0.3.0 plus a state-init fix.)
 
@@ -256,8 +256,19 @@ Skills are YAML prompt templates in `skills/` with an `output_schema` the engine
 draftcat                       # run the engine (validates config first; refuses to start on errors)
 draftcat validate [--strict]   # lint config + skills
 draftcat test <pipeline>       # dry-run against fixtures/<pipeline>/ (never touches real APIs)
+draftcat runs [pipeline]       # recent runs + the approval decisions in each (--json to archive)
 draftcat audit-verify          # verify signed approval receipts
 ```
+
+`draftcat runs` reads the governance record back out of SQLite — what ran, when, and who decided what:
+
+```
+2026-07-26T05:37:31Z  invoices    ok    60.0s
+    release-payment      adjust      by 111 (0/2)
+    release-payment      approve     by 222 (2/2) [signed]
+```
+
+Per-step timings and token counts are not here — those are observability spans (`observability.spans`, OTLP/Prometheus). This is the durable record of decisions.
 
 Pre-commit hooks (lefthook) run `gofmt`, `go vet`, `go build`, `go test -short`, and `golangci-lint` on new code; pre-push runs `draftcat validate`.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 
 Draftcat runs YAML-defined pipelines that triage email, qualify leads, draft replies, extract data from PDFs, and govern self-hosted voice AI. Every outbound action passes an operator approval gate, every LLM call is budget-checked, and every fetched item is deduped against a SQLite state store. One business per instance, self-hosted, auditable.
 
+> **New in v0.4.0:** approval gates now survive a restart (an interrupted gate is recorded and the operator told the action did *not* run), spend caps in money (`per_day_cost`), per-step `approvers`, body-signed webhooks (`require_signature`), config validated on the boot path, and WhatsApp intake (`whatsapp_intake`).
+>
+> **In v0.3.1:** multi-operator quorum approval (`quorum: N`), tamper-evident signed approval receipts (`draftcat audit-verify`), and OTLP + Prometheus exporters. (v0.3.1 is v0.3.0 plus a state-init fix.)
+
 ![Demo](demo.gif)
 
 ## How draftcat fits
@@ -286,9 +290,9 @@ The deterministic-boundary architecture is documented in the **Production AI Aut
 
 ## Status
 
-**v0.2.2** — early access. Single-business, single-operator deployments. Public APIs may change between minor versions until v1.0.
+**v0.4.0** — early access. Single-business deployments; multi-operator approval is supported via `quorum` + `approvers`. Public APIs may change between minor versions until v1.0.
 
-New in v0.2: webhook triggers (`schedule: webhook`), structured observability spans, and `enum` / `number` enforcement in output schemas. Planned: a generic HTTP action, per-step retry + circuit breaker, Slack approval, and an OpenTelemetry/Prometheus span exporter.
+Planned: a generic HTTP action, per-step retry + circuit breaker, and resuming an interrupted pipeline at its approval step rather than only recording it. Telegram is the only implemented operator channel — a second channel is a real piece of work, not a config flag, so `channel:` accepts only what ships (see `internal/channels`).
 
 ## License
 

--- a/internal/channels/channels.go
+++ b/internal/channels/channels.go
@@ -1,0 +1,47 @@
+// Package channels is the single source of truth for which operator channels
+// draftcat actually implements.
+//
+// The validator (internal/validate) and the engine (package main) both read
+// this list, so a config that passes `draftcat validate` cannot name a channel
+// the engine would silently ignore at runtime. Before this package existed the
+// two disagreed: "slack" was accepted by the validator, no Slack channel was
+// ever built, and step.Channel was never read — so an operator who wrote
+// `channel: slack` got a clean validate run and their approvals went to
+// Telegram anyway. An approval gate that routes somewhere the operator is not
+// watching is worse than no gate, because it still looks like it held.
+//
+// A name belongs here ONLY when a working OperatorChannel implementation ships
+// in the binary. Adding a name without an implementation reintroduces exactly
+// the trap this package exists to close.
+package channels
+
+import "sort"
+
+// Telegram is the only implemented operator channel today.
+const Telegram = "telegram"
+
+// implemented maps channel name -> one-line description, shown in validator
+// messages so the operator sees what they can actually pick.
+var implemented = map[string]string{
+	Telegram: "Telegram bot with inline approve/skip/adjust buttons",
+}
+
+// IsImplemented reports whether name is a channel the engine can actually
+// route an approval to.
+func IsImplemented(name string) bool {
+	_, ok := implemented[name]
+	return ok
+}
+
+// Names returns the implemented channel names, sorted, for error messages.
+func Names() []string {
+	out := make([]string, 0, len(implemented))
+	for k := range implemented {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Describe returns the one-line description for name, or "" if unimplemented.
+func Describe(name string) string { return implemented[name] }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,18 @@ type BudgetConfig struct {
 	PerDayTokens      int `yaml:"per_day_tokens"`
 	PerDayCalls       int `yaml:"per_day_calls"`
 	PerDayCallMinutes int `yaml:"per_day_call_minutes"`
+	// PerDayCost / PerPipelineCost cap spend in MONEY rather than tokens, using
+	// the same unit as models.<role>.cost_per_1k_input/output (draftcat does not
+	// assume a currency — put your provider's rates in and the cap matches them).
+	// Token caps answer "how much did it think"; these answer the question an
+	// owner actually asks, "what will this cost me today". 0 = no cap, so
+	// existing configs are unaffected.
+	//
+	// Enforcement is BETWEEN calls: a call is refused once spend has already
+	// reached the cap, so a single in-flight call can overshoot by at most one
+	// step. Pair with per_step_tokens to bound that overshoot.
+	PerDayCost      float64 `yaml:"per_day_cost"`
+	PerPipelineCost float64 `yaml:"per_pipeline_cost"`
 }
 
 type TimeoutConfig struct {
@@ -102,7 +114,25 @@ type WebhookConfig struct {
 	// MaxBodyBytes caps the request body read into data["webhook_body"].
 	// Default 65536.
 	MaxBodyBytes int64 `yaml:"max_body_bytes"`
-	secret       string
+	// RequireSignature demands a body-bound HMAC signature header on every
+	// request, on top of the bearer token:
+	//
+	//     X-Draftcat-Signature: t=<unix>,v1=<hex hmac-sha256(t + "." + body)>
+	//
+	// A bearer token alone proves only that the caller once saw the token — a
+	// captured header replays forever and the body is not bound to it, so an
+	// intercepted request can be re-fired, or its body swapped, to start a
+	// pipeline. The signature binds caller, body and time, which is the
+	// Stripe/GitHub webhook norm.
+	//
+	// Default false keeps existing deployments working. Note that a signature
+	// header, once present, is ALWAYS verified even when this is false — a
+	// signer that breaks should fail loudly rather than be silently ignored.
+	RequireSignature bool `yaml:"require_signature"`
+	// MaxSkewSeconds bounds how far the signed timestamp may be from now, in
+	// either direction. Default 300 (5 minutes).
+	MaxSkewSeconds int64 `yaml:"max_skew_seconds"`
+	secret         string
 }
 
 // Secret / SetSecret access the runtime-resolved webhook token (never parsed from YAML).
@@ -157,4 +187,16 @@ type StepConfig struct {
 	// approval step before the action is released. 0 or 1 = single approver
 	// (default, unchanged behavior). Only the telegram channel implements N>=2.
 	Quorum int `yaml:"quorum"`
+	// Approvers narrows WHO may decide this step to a subset of the channel's
+	// allowed_users. Empty = anyone on allowed_users, i.e. today's behavior.
+	//
+	// allowed_users is one flat list and quorum is only a count, so until now
+	// every operator could approve every action: the assistant who triages
+	// inbox drafts could also release an invoice. This is the missing axis —
+	// quorum says how many, approvers says which ones.
+	//
+	// A quorum step needs at least Quorum entries here or it can never be
+	// satisfied; the validator enforces that rather than letting it hang until
+	// the approval timeout.
+	Approvers []int64 `yaml:"approvers"`
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -71,6 +71,17 @@ CREATE TABLE IF NOT EXISTS action_approvals (
     signature    TEXT    NOT NULL DEFAULT ''  -- HMAC receipt over the row's fields (empty = unsigned)
 );
 CREATE INDEX IF NOT EXISTS idx_approvals_pipeline ON action_approvals(pipeline, decided_at DESC);
+CREATE TABLE IF NOT EXISTS pending_approvals (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    pipeline     TEXT    NOT NULL,
+    step         TEXT    NOT NULL,
+    payload_hash TEXT    NOT NULL,           -- sha256 hex of the draft shown (never the draft)
+    quorum_n     INTEGER NOT NULL DEFAULT 1, -- approvals required
+    opened_at    INTEGER NOT NULL,           -- unix seconds the gate was opened
+    expires_at   INTEGER NOT NULL,           -- unix seconds the gate would time out
+    status       TEXT    NOT NULL            -- pending|resolved|interrupted
+);
+CREATE INDEX IF NOT EXISTS idx_pending_status ON pending_approvals(status, opened_at);
 `
 	if _, err := db.ExecContext(context.Background(), schema); err != nil {
 		return err
@@ -335,6 +346,101 @@ func (s *StateStore) UnapprovedActions(pipeline string) ([]string, error) {
 		out = append(out, step)
 	}
 	return out, rows.Err()
+}
+
+// --- Pending approvals (crash/restart durability) ---
+//
+// An approval gate used to exist only inside an in-process poll loop: the
+// engine sent the draft, blocked on a ticker, and wrote to action_approvals
+// only once a decision arrived. If the process restarted while a gate was open
+// — a redeploy, an OOM, a VPS reboot — the open gate left no trace at all. The
+// operator saw a live-looking message with buttons, the run was gone, and
+// UnapprovedActions could not see the hole because nothing was ever written.
+//
+// These three calls make the gate durable: a row is written BEFORE the draft is
+// sent, resolved when a decision arrives, and reconciled to `interrupted` on
+// the next boot if neither happened. The outcome of every gate is therefore
+// always knowable, even the ones that were cut off mid-flight.
+
+// PendingApproval is one approval gate that was open when the process stopped.
+type PendingApproval struct {
+	ID          int64
+	Pipeline    string
+	Step        string
+	PayloadHash string
+	QuorumN     int
+	OpenedAt    time.Time
+	ExpiresAt   time.Time
+}
+
+// BeginApproval records an approval gate as open and returns its row id. Called
+// immediately BEFORE the draft goes out to the operator channel, so a crash in
+// the window between sending and deciding is still visible afterwards. Like the
+// audit table it stores only the sha256 of the draft, never the draft itself.
+func (s *StateStore) BeginApproval(pipeline, step, payloadHash string, quorumN int, openedAt, expiresAt time.Time) (int64, error) {
+	if s == nil || s.db == nil {
+		return 0, nil
+	}
+	res, err := s.db.ExecContext(context.Background(),
+		`INSERT INTO pending_approvals (pipeline, step, payload_hash, quorum_n, opened_at, expires_at, status)
+		 VALUES (?, ?, ?, ?, ?, ?, 'pending')`,
+		pipeline, step, payloadHash, quorumN, openedAt.Unix(), expiresAt.Unix(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// ResolveApproval closes an open gate once a terminal decision was reached.
+// A zero id is a no-op so callers need not special-case a store-less run.
+func (s *StateStore) ResolveApproval(id int64) error {
+	if s == nil || s.db == nil || id == 0 {
+		return nil
+	}
+	_, err := s.db.ExecContext(context.Background(),
+		`UPDATE pending_approvals SET status='resolved' WHERE id=? AND status='pending'`, id)
+	return err
+}
+
+// InterruptedApprovals returns every gate still marked pending — by definition
+// gates that were open when the process last stopped, since a live run resolves
+// its own row. Call once on boot, before the engine starts.
+func (s *StateStore) InterruptedApprovals() ([]PendingApproval, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(context.Background(),
+		`SELECT id, pipeline, step, payload_hash, quorum_n, opened_at, expires_at
+		   FROM pending_approvals WHERE status='pending' ORDER BY opened_at`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []PendingApproval
+	for rows.Next() {
+		var p PendingApproval
+		var opened, expires int64
+		if err := rows.Scan(&p.ID, &p.Pipeline, &p.Step, &p.PayloadHash, &p.QuorumN, &opened, &expires); err != nil {
+			return nil, err
+		}
+		p.OpenedAt = time.Unix(opened, 0)
+		p.ExpiresAt = time.Unix(expires, 0)
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// MarkInterrupted flips a pending gate to `interrupted`, the terminal state for
+// "the process died before the operator decided". The caller is expected to
+// also write an audit row so the compliance queries see it.
+func (s *StateStore) MarkInterrupted(id int64) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	_, err := s.db.ExecContext(context.Background(),
+		`UPDATE pending_approvals SET status='interrupted' WHERE id=? AND status='pending'`, id)
+	return err
 }
 
 func (s *StateStore) Close() error {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -225,6 +225,33 @@ func (s *StateStore) RecentRuns(pipeline string, n int) ([]RunRecord, error) {
 // Signature are the tamper-evidence receipt: empty on rows written before signing
 // was configured (or when no secret is set), otherwise an HMAC over the other
 // fields under the operator's approval-signing secret.
+// AllRecentRuns is RecentRuns across every pipeline, newest first. Used by
+// `draftcat runs` when no pipeline is named.
+func (s *StateStore) AllRecentRuns(n int) ([]RunRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(context.Background(),
+		`SELECT pipeline, started_at, ended_at, status, COALESCE(error_text,'')
+		   FROM pipeline_runs ORDER BY started_at DESC LIMIT ?`, n)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []RunRecord
+	for rows.Next() {
+		var r RunRecord
+		var st, en int64
+		if err := rows.Scan(&r.Pipeline, &st, &en, &r.Status, &r.Error); err != nil {
+			return nil, err
+		}
+		r.StartedAt = time.Unix(st, 0)
+		r.EndedAt = time.Unix(en, 0)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 type ApprovalRecord struct {
 	Pipeline    string
 	Step        string

--- a/internal/state/state_pending_test.go
+++ b/internal/state/state_pending_test.go
@@ -1,0 +1,139 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+// The pending_approvals table exists so an approval gate that was open when the
+// process stopped is still knowable afterwards. These tests pin the three
+// transitions the reconciler depends on.
+
+func TestPendingApproval_OpenGateIsReportedAfterRestart(t *testing.T) {
+	s := newTempStore(t)
+
+	now := time.Now()
+	id, err := s.BeginApproval("invoices", "release", "abc123", 2, now, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("BeginApproval: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("BeginApproval returned id 0, want a real row id")
+	}
+
+	// A fresh process asks what was left open.
+	open, err := s.InterruptedApprovals()
+	if err != nil {
+		t.Fatalf("InterruptedApprovals: %v", err)
+	}
+	if len(open) != 1 {
+		t.Fatalf("got %d open gate(s), want 1", len(open))
+	}
+	got := open[0]
+	if got.Pipeline != "invoices" || got.Step != "release" {
+		t.Errorf("gate = %s/%s, want invoices/release", got.Pipeline, got.Step)
+	}
+	if got.PayloadHash != "abc123" {
+		t.Errorf("PayloadHash = %q, want abc123", got.PayloadHash)
+	}
+	if got.QuorumN != 2 {
+		t.Errorf("QuorumN = %d, want 2", got.QuorumN)
+	}
+	if got.OpenedAt.Unix() != now.Unix() {
+		t.Errorf("OpenedAt = %v, want %v", got.OpenedAt.Unix(), now.Unix())
+	}
+}
+
+// A gate that reached a decision in-process must NOT be reported as
+// interrupted on the next boot — otherwise every clean run would generate a
+// false "your approval was lost" notice.
+func TestPendingApproval_ResolvedGateIsNotInterrupted(t *testing.T) {
+	s := newTempStore(t)
+
+	now := time.Now()
+	id, err := s.BeginApproval("leads", "gate", "hash", 1, now, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("BeginApproval: %v", err)
+	}
+	if err := s.ResolveApproval(id); err != nil {
+		t.Fatalf("ResolveApproval: %v", err)
+	}
+
+	open, err := s.InterruptedApprovals()
+	if err != nil {
+		t.Fatalf("InterruptedApprovals: %v", err)
+	}
+	if len(open) != 0 {
+		t.Fatalf("got %d open gate(s) after resolve, want 0", len(open))
+	}
+}
+
+// Reconciliation must be idempotent: booting twice cannot report the same
+// interrupted gate twice, or a crash loop would spam the operator and inflate
+// the audit log.
+func TestPendingApproval_MarkInterruptedIsTerminal(t *testing.T) {
+	s := newTempStore(t)
+
+	now := time.Now()
+	id, _ := s.BeginApproval("p", "gate", "h", 1, now, now.Add(time.Hour))
+
+	if err := s.MarkInterrupted(id); err != nil {
+		t.Fatalf("MarkInterrupted: %v", err)
+	}
+	open, err := s.InterruptedApprovals()
+	if err != nil {
+		t.Fatalf("InterruptedApprovals: %v", err)
+	}
+	if len(open) != 0 {
+		t.Fatalf("second boot saw %d gate(s), want 0 — reconciliation is not idempotent", len(open))
+	}
+
+	// And a late resolve of an already-interrupted row must not resurrect it.
+	if err := s.ResolveApproval(id); err != nil {
+		t.Fatalf("ResolveApproval after interrupt: %v", err)
+	}
+	open, _ = s.InterruptedApprovals()
+	if len(open) != 0 {
+		t.Fatalf("row resurfaced after late resolve: %d", len(open))
+	}
+}
+
+// Several gates can be open at once (concurrent pipelines); all must survive.
+func TestPendingApproval_MultipleOpenGates(t *testing.T) {
+	s := newTempStore(t)
+
+	now := time.Now()
+	for _, name := range []string{"a", "b", "c"} {
+		if _, err := s.BeginApproval(name, "gate", "h-"+name, 1, now, now.Add(time.Hour)); err != nil {
+			t.Fatalf("BeginApproval(%s): %v", name, err)
+		}
+	}
+	open, err := s.InterruptedApprovals()
+	if err != nil {
+		t.Fatalf("InterruptedApprovals: %v", err)
+	}
+	if len(open) != 3 {
+		t.Fatalf("got %d open gate(s), want 3", len(open))
+	}
+}
+
+// A nil store is the "no state configured" path. Every call must be a safe
+// no-op so the engine still runs approvals without a database.
+func TestPendingApproval_NilStoreIsSafe(t *testing.T) {
+	var s *StateStore
+
+	id, err := s.BeginApproval("p", "s", "h", 1, time.Now(), time.Now())
+	if err != nil || id != 0 {
+		t.Fatalf("BeginApproval on nil store = (%d, %v), want (0, nil)", id, err)
+	}
+	if err := s.ResolveApproval(0); err != nil {
+		t.Fatalf("ResolveApproval on nil store: %v", err)
+	}
+	if err := s.MarkInterrupted(1); err != nil {
+		t.Fatalf("MarkInterrupted on nil store: %v", err)
+	}
+	open, err := s.InterruptedApprovals()
+	if err != nil || len(open) != 0 {
+		t.Fatalf("InterruptedApprovals on nil store = (%v, %v), want (empty, nil)", open, err)
+	}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -294,6 +294,13 @@ func checkPipelines(cfg *config.Config, skills map[string]*skillsapi.SkillDef, s
 		}
 		seen[p.Name] = true
 
+		// A pipeline with no steps is almost always a half-finished edit or a
+		// YAML indentation slip. It schedules, runs, and does nothing, which
+		// looks like success — so it is an error, not a warning.
+		if len(p.Steps) == 0 {
+			rep.errf(path+".steps", "pipeline has no steps — it would run and do nothing")
+		}
+
 		switch p.Schedule {
 		case "", "manual":
 			// operator /run only
@@ -314,13 +321,15 @@ func checkPipelines(cfg *config.Config, skills map[string]*skillsapi.SkillDef, s
 				rep.errf(spath, "missing 'name'")
 			}
 			if !validStepTypes[st.Type] {
-				rep.errf(spath+".type", "invalid type %q (must be one of: deterministic, ai, approval)", st.Type)
+				rep.errf(spath+".type", "invalid type %q%s (must be one of: deterministic, ai, approval)",
+					st.Type, didYouMean(st.Type, stepTypeNames()))
 				continue
 			}
 			switch st.Type {
 			case "deterministic":
 				if _, ok := validKnownActions[st.Action]; !ok {
-					rep.errf(spath+".action", "unknown action %q (known: %s)", st.Action, strings.Join(knownActionNames(), ", "))
+					rep.errf(spath+".action", "unknown action %q%s (known: %s)",
+						st.Action, didYouMean(st.Action, knownActionNames()), strings.Join(knownActionNames(), ", "))
 				}
 				if st.Action == "ghl_stale_opportunities" && st.Vars["pipeline_id"] == "" {
 					rep.errf(spath+".vars.pipeline_id", "ghl_stale_opportunities requires vars.pipeline_id")
@@ -553,3 +562,102 @@ func knownActionNames() []string {
 }
 
 func knownApprovalChannels() []string { return channels.Names() }
+
+func stepTypeNames() []string {
+	out := make([]string, 0, len(validStepTypes))
+	for k := range validStepTypes {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// didYouMean returns ` — did you mean "ai"?` when got is a near miss for one of
+// the candidates, or "" when nothing is close enough. A typo'd step type or
+// action is the single most common config mistake, and "invalid type" plus a
+// list of twelve valid names makes the reader do the diffing. Naming the likely
+// intent turns that into a one-second fix.
+//
+// The cutoff is deliberately tight (edit distance <= 2, and never more than a
+// third of the word): a wrong-but-not-similar value is a different mistake, and
+// a confidently wrong suggestion is worse than none.
+func didYouMean(got string, candidates []string) string {
+	if got == "" {
+		return ""
+	}
+	best, bestDist := "", 1<<30
+	for _, c := range candidates {
+		if c == "" {
+			continue
+		}
+		d := editDistance(strings.ToLower(got), strings.ToLower(c))
+		if d < bestDist {
+			best, bestDist = c, d
+		}
+	}
+	limit := len(got) / 3
+	if limit > 2 {
+		limit = 2
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if best == "" || bestDist > limit {
+		return ""
+	}
+	return fmt.Sprintf(" — did you mean %q?", best)
+}
+
+// editDistance is Damerau-Levenshtein (optimal string alignment), i.e.
+// Levenshtein plus adjacent transposition as a single edit.
+//
+// Transposition has to count as one edit or the most common typo of all is
+// missed: "ia" -> "ai" is two substitutions under plain Levenshtein, which
+// pushes it past the cutoff on a short word and loses exactly the suggestion
+// the config linter most wants to make.
+func editDistance(a, b string) int {
+	if a == b {
+		return 0
+	}
+	ar, br := []rune(a), []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+	// Full matrix: the transposition rule needs row i-2.
+	d := make([][]int, len(ar)+1)
+	for i := range d {
+		d[i] = make([]int, len(br)+1)
+		d[i][0] = i
+	}
+	for j := 0; j <= len(br); j++ {
+		d[0][j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			d[i][j] = min3(d[i][j-1]+1, d[i-1][j]+1, d[i-1][j-1]+cost)
+			if i > 1 && j > 1 && ar[i-1] == br[j-2] && ar[i-2] == br[j-1] {
+				if t := d[i-2][j-2] + 1; t < d[i][j] {
+					d[i][j] = t
+				}
+			}
+		}
+	}
+	return d[len(ar)][len(br)]
+}
+
+func min3(a, b, c int) int {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		a = c
+	}
+	return a
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -3,8 +3,6 @@ package validate
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/renezander030/draftcat/internal/config"
-	skillsapi "github.com/renezander030/draftcat/internal/skills"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -13,6 +11,10 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/renezander030/draftcat/internal/channels"
+	"github.com/renezander030/draftcat/internal/config"
+	skillsapi "github.com/renezander030/draftcat/internal/skills"
 )
 
 // validKnownActions mirrors the deterministic action switch in runPipeline.
@@ -35,10 +37,9 @@ var validStepTypes = map[string]bool{
 	"approval":      true,
 }
 
-var validApprovalChannels = map[string]bool{
-	"telegram": true,
-	"slack":    true,
-}
+// Implemented operator channels come from internal/channels, which the engine
+// reads too. Keeping a second list here is what let `channel: slack` pass
+// validation for a channel that was never built.
 
 type validateFinding struct {
 	Level   string `json:"level"`
@@ -119,16 +120,52 @@ func Run(args []string) int {
 		return printValidateReport(rep, jsonOut, strict)
 	}
 
-	skills := loadSkillsForValidate(skillsDir, rep)
-	checkConfigSecurity(&cfg, rep)
-	checkTimeouts(&cfg, rep)
-	checkRolesToModels(&cfg, rep)
-	checkEnvVars(&cfg, rep)
-	checkPipelines(&cfg, skills, skillsDir, rep)
-	checkOrphanedSkills(&cfg, skills, rep)
-	checkSecretsHygiene(rep)
+	runChecks(&cfg, skillsDir, rep)
 
 	return printValidateReport(rep, jsonOut, strict)
+}
+
+// runChecks is the shared check body behind both `draftcat validate` and the
+// engine's startup gate, so the two can never drift into disagreeing about
+// what a valid config is.
+func runChecks(cfg *config.Config, skillsDir string, rep *validateReport) {
+	skills := loadSkillsForValidate(skillsDir, rep)
+	checkConfigSecurity(cfg, rep)
+	checkTimeouts(cfg, rep)
+	checkRolesToModels(cfg, rep)
+	checkEnvVars(cfg, rep)
+	checkPipelines(cfg, skills, skillsDir, rep)
+	checkOrphanedSkills(cfg, skills, rep)
+	checkSecretsHygiene(rep)
+}
+
+// Finding is one validation result surfaced to the engine at startup.
+type Finding struct {
+	Level   string // "error" | "warn"
+	Path    string
+	Message string
+}
+
+// CheckAtStartup runs the same checks as `draftcat validate` against an
+// already-parsed config and returns the findings.
+//
+// Validation used to be opt-in: thorough, but only if someone remembered to run
+// it. A config with a typo'd role or an unimplemented channel booted happily and
+// failed hours later at step-run time, which is the worst moment to discover it
+// — mid-pipeline, with a half-finished action and an operator who did not cause
+// the problem. Running it on the boot path turns a 3am runtime failure into a
+// startup refusal.
+//
+// The engine treats errors as fatal and warnings as logged. Returned rather than
+// printed so the caller controls presentation.
+func CheckAtStartup(cfg *config.Config, skillsDir string) []Finding {
+	rep := &validateReport{}
+	runChecks(cfg, skillsDir, rep)
+	out := make([]Finding, 0, len(rep.Findings))
+	for _, f := range rep.Findings {
+		out = append(out, Finding(f))
+	}
+	return out
 }
 
 func loadSkillsForValidate(skillsDir string, rep *validateReport) map[string]*skillsapi.SkillDef {
@@ -330,10 +367,15 @@ func checkPipelines(cfg *config.Config, skills map[string]*skillsapi.SkillDef, s
 				if st.Mode != "" && st.Mode != "hitl" {
 					rep.warnf(spath+".mode", "only 'hitl' is supported (got %q)", st.Mode)
 				}
+				// An unimplemented channel is an ERROR, not a warning. The
+				// engine routes approvals to the one channel it is running;
+				// naming any other means the operator would be watching a
+				// channel the draft never reaches, while validate said OK.
 				if st.Channel == "" {
 					rep.errf(spath+".channel", "approval step requires 'channel'")
-				} else if !validApprovalChannels[st.Channel] {
-					rep.warnf(spath+".channel", "unknown channel %q (known: %s)", st.Channel, strings.Join(knownApprovalChannels(), ", "))
+				} else if !channels.IsImplemented(st.Channel) {
+					rep.errf(spath+".channel", "channel %q is not implemented — approvals cannot be routed there (implemented: %s)",
+						st.Channel, strings.Join(knownApprovalChannels(), ", "))
 				}
 				// Quorum (N-of-M) validation.
 				if st.Quorum < 0 {
@@ -343,9 +385,14 @@ func checkPipelines(cfg *config.Config, skills map[string]*skillsapi.SkillDef, s
 					rep.errf(spath+".quorum", "quorum %d exceeds the %d allowed operator(s) — unsatisfiable",
 						st.Quorum, len(cfg.Telegram.Security.AllowedUsers))
 				}
-				if st.Quorum >= 2 && st.Channel != "telegram" {
+				if st.Quorum >= 2 && st.Channel != channels.Telegram {
 					rep.errf(spath+".quorum", "quorum >= 2 requires channel 'telegram' (only telegram implements multi-operator approval), got %q", st.Channel)
 				}
+				// Approver scoping: a step can only narrow the channel's allowed
+				// users, never widen them, and must leave enough approvers to
+				// satisfy its own quorum — otherwise the gate hangs until the
+				// approval timeout instead of failing at startup.
+				checkApprovers(cfg, st, spath, rep)
 			}
 		}
 
@@ -355,6 +402,42 @@ func checkPipelines(cfg *config.Config, skills map[string]*skillsapi.SkillDef, s
 					aiSteps, cfg.Budgets.PerStepTokens*aiSteps, cfg.Budgets.PerPipelineTokens)
 			}
 		}
+	}
+}
+
+// checkApprovers validates a step's approver narrowing. The engine intersects
+// step.approvers with the channel's allowed_users and never widens, so an id
+// that is not an allowed user is dead weight that silently shrinks the real
+// approver pool — worth an error while the operator is still looking at it,
+// not a surprise at 4am when the gate cannot be satisfied.
+func checkApprovers(cfg *config.Config, st config.StepConfig, spath string, rep *validateReport) {
+	if len(st.Approvers) == 0 {
+		return
+	}
+	allowed := map[int64]bool{}
+	for _, id := range cfg.Telegram.Security.AllowedUsers {
+		allowed[id] = true
+	}
+	seen := map[int64]bool{}
+	valid := 0
+	for _, id := range st.Approvers {
+		if seen[id] {
+			rep.warnf(spath+".approvers", "operator %d listed more than once (counted once)", id)
+			continue
+		}
+		seen[id] = true
+		if !allowed[id] {
+			rep.errf(spath+".approvers", "operator %d is not in telegram.security.allowed_users — cannot approve anything", id)
+			continue
+		}
+		valid++
+	}
+	need := st.Quorum
+	if need < 1 {
+		need = 1
+	}
+	if valid < need {
+		rep.errf(spath+".approvers", "%d valid approver(s) cannot satisfy quorum %d — gate would hang until timeout", valid, need)
 	}
 }
 
@@ -469,11 +552,4 @@ func knownActionNames() []string {
 	return out
 }
 
-func knownApprovalChannels() []string {
-	var out []string
-	for k := range validApprovalChannels {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
-}
+func knownApprovalChannels() []string { return channels.Names() }

--- a/internal/validate/validate_channel_test.go
+++ b/internal/validate/validate_channel_test.go
@@ -1,0 +1,154 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/renezander030/draftcat/internal/config"
+)
+
+func findingsAt(rep *validateReport, level, pathFragment string) []validateFinding {
+	var out []validateFinding
+	for _, f := range rep.Findings {
+		if f.Level == level && strings.Contains(f.Path, pathFragment) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func approvalCfg(step config.StepConfig, allowed ...int64) *config.Config {
+	if len(allowed) == 0 {
+		allowed = []int64{111, 222, 333}
+	}
+	return &config.Config{
+		Telegram: config.TelegramConfig{
+			Security: config.ChannelSecurity{AllowedUsers: allowed},
+		},
+		Pipelines: []config.PipelineConfig{{Name: "p", Steps: []config.StepConfig{step}}},
+	}
+}
+
+// The regression this whole change exists for: `channel: slack` used to sit in
+// the validator's allow-list while no Slack channel was ever implemented and
+// step.Channel was never read at runtime. Validation said OK and approvals went
+// to Telegram — an approval gate routing somewhere the operator is not watching
+// is worse than no gate, because it still looks like it held.
+func TestValidateRejectsUnimplementedChannel(t *testing.T) {
+	cfg := approvalCfg(config.StepConfig{
+		Name: "gate", Type: "approval", Channel: "slack",
+	})
+	rep := runCheckPipelines(cfg)
+
+	errs := findingsAt(rep, "error", ".channel")
+	if len(errs) == 0 {
+		t.Fatalf("channel 'slack' must be a hard error while unimplemented; findings: %+v", rep.Findings)
+	}
+	if !strings.Contains(errs[0].Message, "not implemented") {
+		t.Errorf("message %q should say the channel is not implemented", errs[0].Message)
+	}
+}
+
+func TestValidateAcceptsImplementedChannel(t *testing.T) {
+	cfg := approvalCfg(config.StepConfig{
+		Name: "gate", Type: "approval", Channel: "telegram",
+	})
+	if errs := findingsAt(runCheckPipelines(cfg), "error", ".channel"); len(errs) != 0 {
+		t.Fatalf("telegram is implemented and must validate cleanly, got %+v", errs)
+	}
+}
+
+func TestValidateRejectsTypoedChannel(t *testing.T) {
+	cfg := approvalCfg(config.StepConfig{
+		Name: "gate", Type: "approval", Channel: "telegramm",
+	})
+	if errs := findingsAt(runCheckPipelines(cfg), "error", ".channel"); len(errs) == 0 {
+		t.Fatal("a typo'd channel name must be an error, not a silent reroute")
+	}
+}
+
+// --- approver scoping ---
+
+// An id that is not an allowed user silently shrinks the real approver pool,
+// which can make a quorum unsatisfiable at 4am. Catch it at config time.
+func TestValidateApproverNotInAllowedUsers(t *testing.T) {
+	cfg := approvalCfg(config.StepConfig{
+		Name: "gate", Type: "approval", Channel: "telegram",
+		Approvers: []int64{999},
+	}, 111, 222)
+
+	errs := findingsAt(runCheckPipelines(cfg), "error", ".approvers")
+	if len(errs) == 0 {
+		t.Fatal("an approver absent from allowed_users must be an error")
+	}
+}
+
+func TestValidateApproversCannotSatisfyQuorum(t *testing.T) {
+	cfg := approvalCfg(config.StepConfig{
+		Name: "gate", Type: "approval", Channel: "telegram",
+		Quorum: 3, Approvers: []int64{111, 222},
+	}, 111, 222, 333)
+
+	errs := findingsAt(runCheckPipelines(cfg), "error", ".approvers")
+	if len(errs) == 0 {
+		t.Fatal("2 approvers cannot satisfy quorum 3 — must error rather than hang until timeout")
+	}
+}
+
+func TestValidateApproversSatisfyingQuorumIsClean(t *testing.T) {
+	cfg := approvalCfg(config.StepConfig{
+		Name: "gate", Type: "approval", Channel: "telegram",
+		Quorum: 2, Approvers: []int64{111, 222},
+	}, 111, 222, 333)
+
+	if errs := findingsAt(runCheckPipelines(cfg), "error", ".approvers"); len(errs) != 0 {
+		t.Fatalf("2 valid approvers satisfy quorum 2, got %+v", errs)
+	}
+}
+
+func TestValidateDuplicateApproverWarnsAndDoesNotCountTwice(t *testing.T) {
+	cfg := approvalCfg(config.StepConfig{
+		Name: "gate", Type: "approval", Channel: "telegram",
+		Quorum: 2, Approvers: []int64{111, 111},
+	}, 111, 222)
+	rep := runCheckPipelines(cfg)
+
+	if warns := findingsAt(rep, "warn", ".approvers"); len(warns) == 0 {
+		t.Error("a duplicated approver id should warn")
+	}
+	// 111 listed twice is still one human, so quorum 2 is unsatisfiable.
+	if errs := findingsAt(rep, "error", ".approvers"); len(errs) == 0 {
+		t.Error("a duplicate must not count twice toward quorum")
+	}
+}
+
+func TestValidateEmptyApproversIsUnscopedAndClean(t *testing.T) {
+	cfg := approvalCfg(config.StepConfig{
+		Name: "gate", Type: "approval", Channel: "telegram", Quorum: 2,
+	}, 111, 222)
+
+	if errs := findingsAt(runCheckPipelines(cfg), "error", ".approvers"); len(errs) != 0 {
+		t.Fatalf("no approvers list means unscoped, which is the pre-existing behavior; got %+v", errs)
+	}
+}
+
+// --- startup gate ---
+
+// CheckAtStartup must run the same checks as the subcommand, so the engine and
+// `draftcat validate` can never disagree about what a valid config is.
+func TestCheckAtStartupReportsErrors(t *testing.T) {
+	cfg := approvalCfg(config.StepConfig{
+		Name: "gate", Type: "approval", Channel: "slack",
+	})
+	findings := CheckAtStartup(cfg, "skills")
+
+	var errs int
+	for _, f := range findings {
+		if f.Level == "error" {
+			errs++
+		}
+	}
+	if errs == 0 {
+		t.Fatalf("startup check must surface the unimplemented-channel error; got %+v", findings)
+	}
+}

--- a/internal/validate/validate_typo_test.go
+++ b/internal/validate/validate_typo_test.go
@@ -1,0 +1,117 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/renezander030/draftcat/internal/config"
+)
+
+// A pipeline with no steps schedules, runs, and does nothing — which looks like
+// success in the logs. Almost always a half-finished edit or a YAML indent slip.
+func TestValidateEmptyPipelineIsError(t *testing.T) {
+	cfg := &config.Config{Pipelines: []config.PipelineConfig{{Name: "empty"}}}
+	if errs := findingsAt(runCheckPipelines(cfg), "error", ".steps"); len(errs) == 0 {
+		t.Fatalf("a pipeline with no steps must error; got %+v", runCheckPipelines(cfg).Findings)
+	}
+}
+
+func TestValidateNonEmptyPipelineHasNoStepsError(t *testing.T) {
+	cfg := &config.Config{Pipelines: []config.PipelineConfig{{
+		Name:  "p",
+		Steps: []config.StepConfig{{Name: "fetch", Type: "deterministic"}},
+	}}}
+	if errs := findingsAt(runCheckPipelines(cfg), "error", ".steps"); len(errs) != 0 {
+		t.Fatalf("a pipeline with steps must not trip the empty check; got %+v", errs)
+	}
+}
+
+// The issue asked for this by name: "unknown type 'ia' — did you mean 'ai'?".
+func TestValidateSuggestsStepTypeTypo(t *testing.T) {
+	cfg := &config.Config{Pipelines: []config.PipelineConfig{{
+		Name:  "p",
+		Steps: []config.StepConfig{{Name: "s", Type: "ia"}},
+	}}}
+	errs := findingsAt(runCheckPipelines(cfg), "error", ".type")
+	if len(errs) == 0 {
+		t.Fatal("an invalid step type must error")
+	}
+	if !strings.Contains(errs[0].Message, `did you mean "ai"`) {
+		t.Errorf("message %q should suggest \"ai\"", errs[0].Message)
+	}
+}
+
+func TestValidateSuggestsActionTypo(t *testing.T) {
+	cfg := &config.Config{Pipelines: []config.PipelineConfig{{
+		Name:  "p",
+		Steps: []config.StepConfig{{Name: "s", Type: "deterministic", Action: "gmail_unred"}},
+	}}}
+	errs := findingsAt(runCheckPipelines(cfg), "error", ".action")
+	if len(errs) == 0 {
+		t.Fatal("an unknown action must error")
+	}
+	if !strings.Contains(errs[0].Message, `did you mean "gmail_unread"`) {
+		t.Errorf("message %q should suggest \"gmail_unread\"", errs[0].Message)
+	}
+}
+
+// A confidently wrong suggestion is worse than none, so a value that is not a
+// near miss must not get one.
+func TestValidateNoSuggestionWhenNothingIsClose(t *testing.T) {
+	cfg := &config.Config{Pipelines: []config.PipelineConfig{{
+		Name:  "p",
+		Steps: []config.StepConfig{{Name: "s", Type: "quantum"}},
+	}}}
+	errs := findingsAt(runCheckPipelines(cfg), "error", ".type")
+	if len(errs) == 0 {
+		t.Fatal("an invalid step type must error")
+	}
+	if strings.Contains(errs[0].Message, "did you mean") {
+		t.Errorf("message %q should not guess for a value nothing is close to", errs[0].Message)
+	}
+}
+
+func TestDidYouMean(t *testing.T) {
+	cands := []string{"deterministic", "ai", "approval"}
+	for _, tc := range []struct {
+		got  string
+		want string // substring, "" = no suggestion
+	}{
+		{"ia", `"ai"`},
+		{"aproval", `"approval"`},
+		{"determinstic", `"deterministic"`},
+		{"", ""},           // nothing typed
+		{"quantum", ""},    // not close to anything
+		{"xyzzyplugh", ""}, // far from everything
+	} {
+		got := didYouMean(tc.got, cands)
+		if tc.want == "" {
+			if got != "" {
+				t.Errorf("didYouMean(%q) = %q, want no suggestion", tc.got, got)
+			}
+			continue
+		}
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("didYouMean(%q) = %q, want it to contain %s", tc.got, got, tc.want)
+		}
+	}
+}
+
+func TestEditDistance(t *testing.T) {
+	for _, tc := range []struct {
+		a, b string
+		want int
+	}{
+		{"ai", "ai", 0},
+		{"ia", "ai", 1},   // adjacent transposition is ONE edit (Damerau)
+		{"ab", "ba", 1},   // ditto
+		{"abc", "cba", 2}, // non-adjacent swap is not a single transposition
+		{"", "abc", 3},
+		{"abc", "", 3},
+		{"kitten", "sitting", 3},
+	} {
+		if got := editDistance(tc.a, tc.b); got != tc.want {
+			t.Errorf("editDistance(%q,%q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
@@ -27,6 +28,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/renezander030/draftcat/internal/approval"
+	"github.com/renezander030/draftcat/internal/channels"
 	ghlapi "github.com/renezander030/draftcat/internal/ghl"
 	gmailapi "github.com/renezander030/draftcat/internal/gmail"
 	"github.com/renezander030/draftcat/internal/obs"
@@ -189,7 +191,16 @@ type BudgetTracker struct {
 	tokensUsedPipeline int
 	callsToday         int
 	callMinutesToday   int
+	costToday          float64
+	costPipeline       float64
 	dayStart           time.Time
+	// Cost caps are held on the tracker rather than passed per call so that
+	// check() enforces them everywhere it is already called. Wiring them at
+	// each of the eight LLM call sites instead would mean a new call site added
+	// later silently spends without a cap — the failure mode is invisible until
+	// the bill arrives. 0 = no cap.
+	dayCostLimit      float64
+	pipelineCostLimit float64
 }
 
 func (b *BudgetTracker) resetIfNewDay() {
@@ -197,6 +208,7 @@ func (b *BudgetTracker) resetIfNewDay() {
 		b.tokensUsedToday = 0
 		b.callsToday = 0
 		b.callMinutesToday = 0
+		b.costToday = 0
 		b.dayStart = time.Now()
 	}
 }
@@ -206,7 +218,8 @@ func (b *BudgetTracker) check(limit int, requested int) error {
 	if b.tokensUsedToday+requested > limit {
 		return fmt.Errorf("BUDGET_BLOCKED: daily token limit %d would be exceeded (used: %d, requested: %d)", limit, b.tokensUsedToday, requested)
 	}
-	return nil
+	// Money caps ride the same pre-call gate as token caps.
+	return b.CheckCost(b.dayCostLimit, b.pipelineCostLimit)
 }
 
 func (b *BudgetTracker) record(tokens int) {
@@ -234,6 +247,35 @@ func (b *BudgetTracker) RecordCall(durationMinutes int) {
 	b.resetIfNewDay()
 	b.callsToday++
 	b.callMinutesToday += durationMinutes
+}
+
+// CheckCost blocks the next LLM call once spend has already reached a cap.
+// Token caps answer "how much did it think"; this answers the question the
+// person paying actually asks — "what is this costing me today". The per-call
+// cost was already computed from the model rates (see callLLM) and then thrown
+// away; now it accumulates and enforces.
+//
+// Deliberately checked BETWEEN calls rather than estimated ahead of one: a
+// pre-call estimate needs the response token count, which does not exist yet,
+// and guessing it either blocks legitimate work or lets the real overshoot
+// through anyway. So a single in-flight call may exceed the cap by at most one
+// step, bounded by per_step_tokens. Limits <= 0 mean "no cap".
+func (b *BudgetTracker) CheckCost(dayLimit, pipelineLimit float64) error {
+	b.resetIfNewDay()
+	if dayLimit > 0 && b.costToday >= dayLimit {
+		return fmt.Errorf("BUDGET_BLOCKED: daily cost limit %.4f reached (spent: %.4f)", dayLimit, b.costToday)
+	}
+	if pipelineLimit > 0 && b.costPipeline >= pipelineLimit {
+		return fmt.Errorf("BUDGET_BLOCKED: per-pipeline cost limit %.4f reached (spent: %.4f)", pipelineLimit, b.costPipeline)
+	}
+	return nil
+}
+
+// RecordCost accumulates the cost of one completed LLM call.
+func (b *BudgetTracker) RecordCost(cost float64) {
+	b.resetIfNewDay()
+	b.costToday += cost
+	b.costPipeline += cost
 }
 
 // --- Input Security ---
@@ -621,14 +663,22 @@ func validateOutput(text string, schema map[string]interface{}) (map[string]inte
 // The engine doesn't know which channel it's talking to.
 
 type OperatorChannel interface {
+	// Name is the channel's config name (see internal/channels). The engine
+	// compares it against a step's `channel:` so a step can never be routed to
+	// a channel that is not the one actually running.
+	Name() string
 	// Send a plain notification (no approval needed)
 	Send(text string) error
-	// Send a draft for approval with action buttons. Returns the operator's decision.
-	SendForApproval(ctx context.Context, draft string) (OperatorDecision, error)
-	// SendForQuorumApproval blocks until `need` distinct allowed operators
-	// approve, or any operator skips/adjusts, or ctx expires. need<=1 behaves
-	// like SendForApproval (single approver).
-	SendForQuorumApproval(ctx context.Context, draft string, need int) (QuorumDecision, error)
+	// SendForApproval sends a draft for approval with action buttons and returns
+	// the operator's decision. `approvers`, when non-empty, narrows who may
+	// decide to that subset of the channel's allowed users; empty = anyone
+	// allowed on the channel.
+	SendForApproval(ctx context.Context, draft string, approvers []int64) (OperatorDecision, error)
+	// SendForQuorumApproval blocks until `need` distinct permitted operators
+	// approve, or any of them skips/adjusts, or ctx expires. need<=1 behaves
+	// like SendForApproval (single approver). `approvers` narrows the permitted
+	// set exactly as above.
+	SendForQuorumApproval(ctx context.Context, draft string, need int, approvers []int64) (QuorumDecision, error)
 }
 
 type OperatorDecision struct {
@@ -790,9 +840,13 @@ func (t *TGBot) answerCallback(callbackID string, text string) {
 	})
 }
 
+// Name identifies this channel to the engine's step routing check.
+func (t *TGBot) Name() string { return channels.Telegram }
+
 // SendForApproval posts a draft with Approve/Skip/Adjust buttons.
 // Waits for the operator to click a button or send a text reply for adjustment.
-func (t *TGBot) SendForApproval(ctx context.Context, draft string) (OperatorDecision, error) {
+// `approvers` narrows who may decide (empty = any allowed user).
+func (t *TGBot) SendForApproval(ctx context.Context, draft string, approvers []int64) (OperatorDecision, error) {
 	buttons := [][]map[string]string{
 		{
 			{"text": "Approve", "callback_data": "approve"},
@@ -827,8 +881,8 @@ func (t *TGBot) SendForApproval(ctx context.Context, draft string) (OperatorDeci
 				// Handle callback query (button click)
 				if u.CallbackQuery != nil {
 					cb := u.CallbackQuery
-					// Security: verify user
-					if !t.isAllowedUser(cb.From.ID) {
+					// Security: verify user is permitted to decide THIS step
+					if !t.isApprover(cb.From.ID, approvers) {
 						t.answerCallback(cb.ID, "") // silent drop
 						log.Printf("[security] REJECTED callback from user %d", cb.From.ID)
 						continue
@@ -864,7 +918,7 @@ func (t *TGBot) SendForApproval(ctx context.Context, draft string) (OperatorDeci
 					if u.Message.Chat.ID != t.chatID {
 						continue
 					}
-					if !t.isAllowedUser(u.Message.From.ID) {
+					if !t.isApprover(u.Message.From.ID, approvers) {
 						log.Printf("[security] REJECTED text from user %d", u.Message.From.ID)
 						continue
 					}
@@ -892,10 +946,10 @@ func (t *TGBot) SendForApproval(ctx context.Context, draft string) (OperatorDeci
 // (allowed-user check, rate limiting, message-ID match, input validation) and
 // adds a live tally. Any single Skip vetoes immediately; Adjust takes the floor
 // and returns so the caller can rewrite and re-enter the gate.
-func (t *TGBot) SendForQuorumApproval(ctx context.Context, draft string, need int) (QuorumDecision, error) {
+func (t *TGBot) SendForQuorumApproval(ctx context.Context, draft string, need int, approvers []int64) (QuorumDecision, error) {
 	if need <= 1 {
 		// Single-approver semantics — delegate so behavior is byte-for-byte today's.
-		d, err := t.SendForApproval(ctx, draft)
+		d, err := t.SendForApproval(ctx, draft, approvers)
 		if err != nil {
 			return QuorumDecision{Action: "timeout"}, err
 		}
@@ -942,7 +996,7 @@ func (t *TGBot) SendForQuorumApproval(ctx context.Context, draft string, need in
 					continue
 				}
 				cb := u.CallbackQuery
-				if !t.isAllowedUser(cb.From.ID) {
+				if !t.isApprover(cb.From.ID, approvers) {
 					t.answerCallback(cb.ID, "") // silent drop
 					log.Printf("[security] REJECTED callback from user %d", cb.From.ID)
 					continue
@@ -986,8 +1040,28 @@ func (t *TGBot) SendForQuorumApproval(ctx context.Context, draft string, need in
 }
 
 func (t *TGBot) isAllowedUser(userID int64) bool {
-	for _, id := range t.security.AllowedUsers {
-		if id == userID {
+	return t.isApprover(userID, nil)
+}
+
+// isApprover reports whether userID may decide a gate whose step narrowed the
+// approver set to `approvers`. The step list is an INTERSECTION with the
+// channel's allowed_users, never a widening: a step cannot grant approval
+// rights to someone the channel does not already trust, so a typo'd id in a
+// step's approvers list fails closed instead of opening the gate. Empty
+// approvers = anyone on allowed_users (today's behavior).
+func (t *TGBot) isApprover(userID int64, approvers []int64) bool {
+	if !containsID(t.security.AllowedUsers, userID) {
+		return false
+	}
+	if len(approvers) == 0 {
+		return true
+	}
+	return containsID(approvers, userID)
+}
+
+func containsID(ids []int64, want int64) bool {
+	for _, id := range ids {
+		if id == want {
 			return true
 		}
 	}
@@ -1058,6 +1132,7 @@ func (t *TGBot) getUpdates() ([]TGUpdate, error) {
 func runPipeline(cfg *config.Config, pipeline config.PipelineConfig, budget *BudgetTracker, ch OperatorChannel, skills *skillsapi.SkillRegistry, seed map[string]interface{}) (err error) {
 	log.Printf("[pipeline:%s] starting", pipeline.Name)
 	budget.tokensUsedPipeline = 0
+	budget.costPipeline = 0
 
 	// Observability: one pipeline span (always) + one span per step. Steps that
 	// run to completion emit at the bottom of the loop; a step that halts the
@@ -1398,6 +1473,7 @@ Description: We need an experienced LLM engineer to build a retrieval-augmented 
 
 			// Record token usage
 			budget.record(resp.InputTokens + resp.OutputTokens)
+			budget.RecordCost(resp.CostUSD)
 			log.Printf("[pipeline:%s][step:%s] model=%s tokens=%d+%d cost=$%.4f latency=%dms",
 				pipeline.Name, step.Name, resp.Model,
 				resp.InputTokens, resp.OutputTokens, resp.CostUSD, resp.LatencyMs)
@@ -1451,18 +1527,27 @@ Description: We need an experienced LLM engineer to build a retrieval-augmented 
 				quorumN = 1
 			}
 
+			// A step may name the channel it wants. Only the running channel can
+			// serve it, so a mismatch is a hard error rather than a silent
+			// reroute to whatever channel happens to be up. `draftcat validate`
+			// catches this before boot; this is the runtime backstop.
+			if step.Channel != "" && step.Channel != ch.Name() {
+				return fmt.Errorf("[step:%s] channel %q is not the running operator channel (%q) — approvals cannot be routed there",
+					step.Name, step.Channel, ch.Name())
+			}
+
 			// getApproval dispatches to the quorum gate when quorum >= 2, else the
 			// single-approver gate (byte-for-byte today's behavior). It normalises
 			// both into (action, adjustText, approvers, err).
 			getApproval := func(cctx context.Context, draft string) (string, string, []int64, error) {
 				if step.Quorum >= 2 {
-					qd, qerr := ch.SendForQuorumApproval(cctx, draft, step.Quorum)
+					qd, qerr := ch.SendForQuorumApproval(cctx, draft, step.Quorum, step.Approvers)
 					if qerr != nil {
 						return "timeout", "", nil, qerr
 					}
 					return qd.Action, qd.Text, qd.Approvers, nil
 				}
-				dec, derr := ch.SendForApproval(cctx, draft)
+				dec, derr := ch.SendForApproval(cctx, draft, step.Approvers)
 				if derr != nil {
 					return "timeout", "", nil, derr
 				}
@@ -1533,9 +1618,28 @@ Description: We need an experienced LLM engineer to build a retrieval-augmented 
 			currentDraft := draftMsg
 			adjustCycles := 0
 			for {
+				// Open the gate durably BEFORE the draft leaves for the operator.
+				// If the process dies in the window between sending and deciding,
+				// the next boot reconciles this row instead of the gate vanishing
+				// without a trace (see reconcileInterruptedApprovals).
+				openedAt := time.Now()
+				pendingSum := sha256.Sum256([]byte(currentDraft))
+				pendingID, perr := state.BeginApproval(pipeline.Name, step.Name,
+					hex.EncodeToString(pendingSum[:]), quorumN, openedAt, openedAt.Add(approvalTimeout))
+				if perr != nil {
+					log.Printf("[pipeline:%s][step:%s] pending-approval write failed: %v", pipeline.Name, step.Name, perr)
+				}
+
 				approvalCtx, approvalCancel := context.WithTimeout(ctx, approvalTimeout)
 				action, adjustText, approvers, aerr := getApproval(approvalCtx, currentDraft)
 				approvalCancel()
+
+				// The gate reached a terminal state in-process, whatever it was —
+				// close the pending row so boot does not later call it interrupted.
+				if rerr := state.ResolveApproval(pendingID); rerr != nil {
+					log.Printf("[pipeline:%s][step:%s] pending-approval resolve failed: %v", pipeline.Name, step.Name, rerr)
+				}
+
 				if aerr != nil {
 					recordAudit("timeout", currentDraft, nil)
 					return fmt.Errorf("[step:%s] %w", step.Name, aerr)
@@ -1591,6 +1695,7 @@ Description: We need an experienced LLM engineer to build a retrieval-augmented 
 					return rerr
 				}
 				budget.record(resp.InputTokens + resp.OutputTokens)
+				budget.RecordCost(resp.CostUSD)
 
 				// Revised draft re-enters the gate (at 0/N for quorum steps).
 				currentDraft = fmt.Sprintf("[draftcat] Revised:\n\n%s", resp.Text)
@@ -1608,6 +1713,74 @@ Description: We need an experienced LLM engineer to build a retrieval-augmented 
 
 	log.Printf("[pipeline:%s] completed. tokens_used=%d", pipeline.Name, budget.tokensUsedPipeline)
 	return nil
+}
+
+// reconcileInterruptedApprovals closes out approval gates that were open when
+// the process last stopped.
+//
+// The gate used to live only in an in-process poll loop, so a redeploy or crash
+// mid-approval left the operator looking at a live-looking message with buttons
+// attached to a run that no longer existed — and, worse, left no record at all:
+// nothing was written until a decision arrived, so the compliance queries could
+// not see the hole either. Now every gate is written down when it opens, and
+// anything still pending at boot is resolved here to `interrupted`: an audit
+// row (so UnapprovedActions counts it) plus a message telling the operator the
+// action did NOT run and the buttons on the old message are dead.
+//
+// Failing closed is the whole point. A gate whose outcome is unknown must never
+// be treated as an approval.
+func reconcileInterruptedApprovals(st *statestore.StateStore, ch OperatorChannel) {
+	pending, err := st.InterruptedApprovals()
+	if err != nil {
+		log.Printf("[approval] could not read pending approvals: %v", err)
+		return
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	secret := []byte(os.Getenv("DRAFTCAT_APPROVAL_SECRET"))
+	log.Printf("[approval] %d approval gate(s) were open at last shutdown — marking interrupted", len(pending))
+
+	for _, p := range pending {
+		decidedAt := time.Now()
+		var nonce, sig string
+		if len(secret) > 0 {
+			if n, nerr := approval.NewNonce(); nerr == nil {
+				nonce = n
+				sig = approval.Sign(secret, approval.Fields{
+					Pipeline: p.Pipeline, Step: p.Step, DecidedAt: decidedAt.Unix(),
+					Decision: "interrupted", OperatorID: 0, PayloadHash: p.PayloadHash,
+					QuorumN: p.QuorumN, QuorumGot: 0,
+				}, nonce)
+			} else {
+				log.Printf("[approval] nonce failed for %s/%s, recording unsigned: %v", p.Pipeline, p.Step, nerr)
+			}
+		}
+		if e := st.RecordApproval(p.Pipeline, p.Step, decidedAt, "interrupted", 0,
+			p.PayloadHash, p.QuorumN, 0, nonce, sig); e != nil {
+			log.Printf("[approval] audit write failed for %s/%s: %v", p.Pipeline, p.Step, e)
+		}
+		if e := st.MarkInterrupted(p.ID); e != nil {
+			log.Printf("[approval] could not mark %d interrupted: %v", p.ID, e)
+		}
+		obs.RecordApproval(p.Pipeline, p.Step, "interrupted")
+		log.Printf("[approval] interrupted: pipeline=%s step=%s opened=%s",
+			p.Pipeline, p.Step, p.OpenedAt.Format(time.RFC3339))
+	}
+
+	if ch != nil {
+		var b strings.Builder
+		fmt.Fprintf(&b, "[draftcat] %d approval(s) were interrupted by a restart. The action was NOT taken.\n",
+			len(pending))
+		for _, p := range pending {
+			fmt.Fprintf(&b, "\n- %s / %s (opened %s)", p.Pipeline, p.Step, p.OpenedAt.Format("2006-01-02 15:04"))
+		}
+		b.WriteString("\n\nButtons on those older messages no longer do anything. Re-run the pipeline if the action is still wanted.")
+		if e := ch.Send(b.String()); e != nil {
+			log.Printf("[approval] could not notify operator of interrupted approvals: %v", e)
+		}
+	}
 }
 
 // --- Command Handler ---
@@ -1790,6 +1963,7 @@ func handleEmails(args string, bot *TGBot, cfg *config.Config, budget *BudgetTra
 			bot.Send(header + formatted[:2000] + "\n\n[truncated]")
 		} else {
 			budget.record(resp.InputTokens + resp.OutputTokens)
+			budget.RecordCost(resp.CostUSD)
 			bot.Send(header + resp.Text)
 		}
 	}
@@ -1883,6 +2057,7 @@ Body:
 			return
 		}
 		budget.record(resp.InputTokens + resp.OutputTokens)
+		budget.RecordCost(resp.CostUSD)
 		replyBody = resp.Text
 	}
 
@@ -1890,7 +2065,9 @@ Body:
 	draft := fmt.Sprintf("[reply] Draft reply to: %s\nSubject: Re: %s\n\n%s", replyTo, subject, replyBody)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Hour)
-	decision, err := bot.SendForApproval(ctx, draft)
+	// Ad-hoc operator command, not a pipeline step — no per-step approver
+	// narrowing applies, so any allowed user may decide.
+	decision, err := bot.SendForApproval(ctx, draft, nil)
 	cancel()
 	if err != nil {
 		log.Printf("[reply] approval error: %v", err)
@@ -2019,6 +2196,7 @@ Thread (%d messages):
 		return
 	}
 	budget.record(resp.InputTokens + resp.OutputTokens)
+	budget.RecordCost(resp.CostUSD)
 	bot.Send(fmt.Sprintf("[thread] %d messages — %s\n\n%s", len(threadEmails), target.Subject, resp.Text))
 }
 
@@ -2347,6 +2525,29 @@ func main() {
 	}
 	skillReg, _ := skillsapi.LoadSkills(skillsDir)
 
+	// Config validation on the boot path. `draftcat validate` runs the very same
+	// checks, but only if someone remembers to; a bad config used to start fine
+	// and fail later mid-pipeline. Errors are fatal here, warnings are logged.
+	// DRAFTCAT_SKIP_VALIDATE=1 is the escape hatch for an operator who needs to
+	// boot a knowingly-imperfect config in an emergency.
+	if os.Getenv("DRAFTCAT_SKIP_VALIDATE") == "" {
+		findings := validate.CheckAtStartup(&cfg, skillsDir)
+		fatal := 0
+		for _, f := range findings {
+			if f.Level == "error" {
+				log.Printf("[config] ERROR %s: %s", f.Path, f.Message)
+				fatal++
+			} else {
+				log.Printf("[config] warn  %s: %s", f.Path, f.Message)
+			}
+		}
+		if fatal > 0 {
+			log.Fatalf("[config] %d error(s) in %s — refusing to start. Fix them, or set DRAFTCAT_SKIP_VALIDATE=1 to override.", fatal, configPath)
+		}
+	} else {
+		log.Printf("[config] WARNING: startup validation skipped (DRAFTCAT_SKIP_VALIDATE set)")
+	}
+
 	// Init Gmail connector if configured
 	if cfg.Gmail.TokenPath != "" {
 		var err error
@@ -2404,8 +2605,18 @@ func main() {
 		security:    cfg.Telegram.Security,
 		rateLimiter: newRateLimiter(cfg.Telegram.Security.RateLimit),
 	}
-	budget := &BudgetTracker{dayStart: time.Now()}
+	budget := &BudgetTracker{
+		dayStart:          time.Now(),
+		dayCostLimit:      cfg.Budgets.PerDayCost,
+		pipelineCostLimit: cfg.Budgets.PerPipelineCost,
+	}
 	chatHistory := newChatHistory(20) // keep last 20 turns
+
+	// Any approval gate still marked pending was open when this process last
+	// stopped. Close it out — audit row plus an operator notice — before the
+	// engine starts, so no gate is left in an unknown state and no stale button
+	// looks live. Needs the bot, hence its position after it.
+	reconcileInterruptedApprovals(state, bot)
 
 	// Observability — structured span emission (off unless opted in).
 	if cfg.Observ.Spans || os.Getenv("DRAFTCAT_TRACE") != "" {
@@ -2553,6 +2764,7 @@ Rules:
 								log.Printf("[intent] classifier error: %v", err)
 							} else {
 								budget.record(intentResp.InputTokens + intentResp.OutputTokens)
+								budget.RecordCost(intentResp.CostUSD)
 								// Parse intent
 								cleaned := strings.TrimSpace(intentResp.Text)
 								if strings.HasPrefix(cleaned, "```") {
@@ -2646,6 +2858,7 @@ Conversation so far:
 								bot.Send("Commands: /help /cron /skills /run /status")
 							} else {
 								budget.record(resp.InputTokens + resp.OutputTokens)
+								budget.RecordCost(resp.CostUSD)
 								log.Printf("[msg] LLM reply (%d tokens, %dms): %s", resp.InputTokens+resp.OutputTokens, resp.LatencyMs, resp.Text[:min(80, len(resp.Text))])
 								chatHistory.Add("assistant", resp.Text)
 								if err := bot.Send(resp.Text); err != nil {
@@ -2736,6 +2949,78 @@ func startWebhookServer(cfg *config.Config, sched *Scheduler, budget *BudgetTrac
 	}()
 }
 
+// webhookSigHeader carries the body-bound HMAC receipt on inbound triggers.
+const webhookSigHeader = "X-Draftcat-Signature"
+
+// verifyWebhookSignature checks the Stripe/GitHub-style receipt
+//
+//	X-Draftcat-Signature: t=<unix>,v1=<hex hmac-sha256(t + "." + body)>
+//
+// A bearer token proves only that the caller once saw the token: it does not
+// bind the request body, and a captured header replays forever. Since a webhook
+// here STARTS a pipeline, that is the one thing an inbound request must not be
+// able to do on its own. Signing t+body and bounding the clock skew closes both
+// holes; the nonce store below closes replay inside the skew window.
+//
+// Errors are deliberately specific for the log and generic for the caller — the
+// handler returns a bare 401 so a prober learns nothing about which check failed.
+func verifyWebhookSignature(header string, body, secret []byte, maxSkewSeconds int64, now time.Time) error {
+	if header == "" {
+		return fmt.Errorf("missing %s header", webhookSigHeader)
+	}
+	var tsPart, sigPart string
+	for _, field := range strings.Split(header, ",") {
+		field = strings.TrimSpace(field)
+		switch {
+		case strings.HasPrefix(field, "t="):
+			tsPart = strings.TrimPrefix(field, "t=")
+		case strings.HasPrefix(field, "v1="):
+			sigPart = strings.TrimPrefix(field, "v1=")
+		}
+	}
+	if tsPart == "" || sigPart == "" {
+		return fmt.Errorf("malformed signature header (want t=<unix>,v1=<hex>)")
+	}
+	ts, err := strconv.ParseInt(tsPart, 10, 64)
+	if err != nil {
+		return fmt.Errorf("unparseable timestamp %q", tsPart)
+	}
+	if skew := now.Unix() - ts; skew > maxSkewSeconds || skew < -maxSkewSeconds {
+		return fmt.Errorf("timestamp outside %ds window (skew %ds)", maxSkewSeconds, skew)
+	}
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(tsPart))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	want := hex.EncodeToString(mac.Sum(nil))
+	if subtle.ConstantTimeCompare([]byte(want), []byte(sigPart)) != 1 {
+		return fmt.Errorf("signature mismatch")
+	}
+
+	// Replay guard. Within the skew window a valid signature is otherwise
+	// reusable, so each one is spent exactly once. Reuses the existing dedup
+	// table rather than adding a second store. With no state store configured
+	// the signature still authenticates — we just cannot promise single-use.
+	if state != nil {
+		unseen, ferr := state.FilterUnseen(webhookReplayScope, "sig", []string{sigPart})
+		if ferr != nil {
+			return fmt.Errorf("replay check failed: %w", ferr)
+		}
+		if len(unseen) == 0 {
+			return fmt.Errorf("signature already used (replay)")
+		}
+		if merr := state.MarkSeen(webhookReplayScope, "sig", []string{sigPart}); merr != nil {
+			return fmt.Errorf("replay record failed: %w", merr)
+		}
+	}
+	return nil
+}
+
+// webhookReplayScope namespaces spent webhook signatures in seen_items. The
+// leading underscores keep it from colliding with a real pipeline name.
+const webhookReplayScope = "__webhook"
+
 // webhookPipelines indexes the pipelines that opted into HTTP triggering.
 func webhookPipelines(cfg *config.Config) map[string]config.PipelineConfig {
 	hookable := map[string]config.PipelineConfig{}
@@ -2756,6 +3041,10 @@ func newWebhookHandler(cfg *config.Config, sched *Scheduler, budget *BudgetTrack
 		maxBody = 65536
 	}
 	secret := []byte(cfg.Webhook.Secret())
+	maxSkew := cfg.Webhook.MaxSkewSeconds
+	if maxSkew <= 0 {
+		maxSkew = 300
+	}
 	hookable := webhookPipelines(cfg)
 
 	mux := http.NewServeMux()
@@ -2773,14 +3062,29 @@ func newWebhookHandler(cfg *config.Config, sched *Scheduler, budget *BudgetTrack
 			return
 		}
 
+		// The body must be read before the signature can be checked, since the
+		// signature covers it — that binding is the point.
+		body, _ := io.ReadAll(io.LimitReader(r.Body, maxBody))
+
+		// A signature is verified whenever it is present, and demanded when
+		// require_signature is on. Verifying an unrequested-but-present header
+		// means a signer that starts emitting bad signatures fails loudly
+		// instead of being silently ignored.
+		sigHeader := r.Header.Get(webhookSigHeader)
+		if sigHeader != "" || cfg.Webhook.RequireSignature {
+			if err := verifyWebhookSignature(sigHeader, body, secret, maxSkew, time.Now()); err != nil {
+				log.Printf("[webhook][security] signature rejected: %v", err)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+
 		name := strings.TrimPrefix(r.URL.Path, "/hooks/")
 		p, ok := hookable[name]
 		if !ok {
 			http.Error(w, "no webhook-triggerable pipeline named "+name, http.StatusNotFound)
 			return
 		}
-
-		body, _ := io.ReadAll(io.LimitReader(r.Body, maxBody))
 
 		ok, reason := sched.TryStart(name)
 		if !ok {

--- a/main.go
+++ b/main.go
@@ -2452,6 +2452,8 @@ func main() {
 			os.Exit(runTestCmd(os.Args[2:]))
 		case "audit-verify":
 			os.Exit(runAuditVerify(os.Args[2:]))
+		case "runs":
+			os.Exit(runRunsCmd(os.Args[2:]))
 		case "-h", "--help", "help":
 			fmt.Println("Draftcat — AI communication management for service businesses.")
 			fmt.Println()
@@ -2459,6 +2461,7 @@ func main() {
 			fmt.Println("  draftcat [config.yaml] [skills/]       run the engine (default)")
 			fmt.Println("  draftcat validate [--strict]           lint config + skills, exit non-zero on errors")
 			fmt.Println("  draftcat test <pipeline>               dry-run a pipeline using fixtures/<pipeline>/")
+			fmt.Println("  draftcat runs [pipeline] [--json]      recent runs + the approval decisions in each")
 			fmt.Println("  draftcat audit-verify <pipeline>       check approval-receipt signatures (needs DRAFTCAT_APPROVAL_SECRET)")
 			return
 		}

--- a/main_approvers_test.go
+++ b/main_approvers_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/renezander030/draftcat/internal/config"
+)
+
+// A step's `approvers:` list narrows who may decide that gate. The critical
+// property is that it INTERSECTS with the channel's allowed_users and never
+// widens it — a step must not be able to hand approval rights to someone the
+// channel does not already trust.
+
+func botWithAllowed(ids ...int64) *TGBot {
+	return &TGBot{security: config.ChannelSecurity{AllowedUsers: ids}}
+}
+
+func TestIsApprover_EmptyListMeansAnyAllowedUser(t *testing.T) {
+	b := botWithAllowed(111, 222)
+	if !b.isApprover(222, nil) {
+		t.Error("with no step scoping, any allowed user may approve")
+	}
+}
+
+func TestIsApprover_NarrowsToListedOperator(t *testing.T) {
+	b := botWithAllowed(111, 222, 333)
+	if !b.isApprover(222, []int64{222}) {
+		t.Error("listed approver 222 should be permitted")
+	}
+	if b.isApprover(333, []int64{222}) {
+		t.Error("operator 333 is allowed on the channel but NOT on this step — must be rejected")
+	}
+}
+
+// The security-critical case: a step cannot widen the channel's trust set.
+// If it could, a typo'd or malicious id in a step would grant approval rights
+// to a stranger.
+func TestIsApprover_CannotWidenBeyondAllowedUsers(t *testing.T) {
+	b := botWithAllowed(111)
+	if b.isApprover(999, []int64{999}) {
+		t.Fatal("step approvers must never grant rights to a non-allowed user — this is a privilege escalation")
+	}
+}
+
+func TestIsApprover_RejectsUnknownUserEntirely(t *testing.T) {
+	b := botWithAllowed(111, 222)
+	if b.isApprover(555, nil) {
+		t.Error("a user absent from allowed_users must always be rejected")
+	}
+}
+
+// isAllowedUser is the pre-existing entry point (used by non-step paths such as
+// the /reply command); it must keep behaving as an unscoped check.
+func TestIsAllowedUser_UnchangedSemantics(t *testing.T) {
+	b := botWithAllowed(111, 222)
+	if !b.isAllowedUser(111) {
+		t.Error("allowed user should pass the unscoped check")
+	}
+	if b.isAllowedUser(333) {
+		t.Error("non-allowed user should fail the unscoped check")
+	}
+}

--- a/main_cost_budget_test.go
+++ b/main_cost_budget_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Cost caps answer the question a business owner actually asks — "what is this
+// costing me today" — which token caps never did. The per-call cost was already
+// being computed and discarded; these tests pin that it now accumulates and
+// blocks.
+
+func TestCheckCost_UnderCapAllows(t *testing.T) {
+	b := &BudgetTracker{dayStart: time.Now(), costToday: 0.5}
+	if err := b.CheckCost(2.0, 0); err != nil {
+		t.Fatalf("spend 0.5 under cap 2.0 should pass, got %v", err)
+	}
+}
+
+func TestCheckCost_AtCapBlocks(t *testing.T) {
+	// Reaching the cap blocks the NEXT call — enforcement is between calls.
+	b := &BudgetTracker{dayStart: time.Now(), costToday: 2.0}
+	err := b.CheckCost(2.0, 0)
+	if err == nil {
+		t.Fatal("spend equal to the cap must block the next call")
+	}
+	if !strings.Contains(err.Error(), "BUDGET_BLOCKED") {
+		t.Errorf("error %q should carry the BUDGET_BLOCKED marker used by the other caps", err)
+	}
+}
+
+func TestCheckCost_PipelineCapIsIndependentOfDailyCap(t *testing.T) {
+	b := &BudgetTracker{dayStart: time.Now(), costToday: 0.1, costPipeline: 5.0}
+	if err := b.CheckCost(100.0, 5.0); err == nil {
+		t.Fatal("per-pipeline cap should block even when the daily cap has room")
+	}
+}
+
+func TestCheckCost_ZeroLimitMeansNoCap(t *testing.T) {
+	// Existing configs have no cost keys at all; they must be unaffected.
+	b := &BudgetTracker{dayStart: time.Now(), costToday: 9999, costPipeline: 9999}
+	if err := b.CheckCost(0, 0); err != nil {
+		t.Fatalf("zero limits mean no cap, got %v", err)
+	}
+}
+
+func TestRecordCost_Accumulates(t *testing.T) {
+	b := &BudgetTracker{dayStart: time.Now()}
+	b.RecordCost(0.25)
+	b.RecordCost(0.75)
+	if b.costToday != 1.0 {
+		t.Errorf("costToday = %v, want 1.0", b.costToday)
+	}
+	if b.costPipeline != 1.0 {
+		t.Errorf("costPipeline = %v, want 1.0", b.costPipeline)
+	}
+}
+
+// The token gate is called before every LLM call; the money gate rides it so a
+// call site added later cannot spend uncapped by forgetting to check.
+func TestCheck_EnforcesCostCapAlongsideTokens(t *testing.T) {
+	b := &BudgetTracker{
+		dayStart:     time.Now(),
+		costToday:    3.0,
+		dayCostLimit: 1.0,
+	}
+	// Plenty of token headroom, but the money cap is blown.
+	err := b.check(1_000_000, 10)
+	if err == nil {
+		t.Fatal("check() must enforce the cost cap, not just tokens")
+	}
+	if !strings.Contains(err.Error(), "cost limit") {
+		t.Errorf("error %q should name the cost limit", err)
+	}
+}
+
+func TestCheck_TokenCapStillEnforcedWithNoCostCap(t *testing.T) {
+	b := &BudgetTracker{dayStart: time.Now(), tokensUsedToday: 900}
+	if err := b.check(1000, 200); err == nil {
+		t.Fatal("token cap must still block when no cost cap is configured")
+	}
+}
+
+// A new day resets spend, matching how token and call counters already behave.
+func TestResetIfNewDay_ClearsCostToday(t *testing.T) {
+	b := &BudgetTracker{
+		dayStart:  time.Now().AddDate(0, 0, -1),
+		costToday: 42.0,
+	}
+	b.resetIfNewDay()
+	if b.costToday != 0 {
+		t.Errorf("costToday = %v after day rollover, want 0", b.costToday)
+	}
+}

--- a/main_quorum_test.go
+++ b/main_quorum_test.go
@@ -12,11 +12,12 @@ import (
 // pure quorumReducer below, no poll loop required.
 type fakeChannel struct{}
 
+func (fakeChannel) Name() string      { return "telegram" }
 func (fakeChannel) Send(string) error { return nil }
-func (fakeChannel) SendForApproval(context.Context, string) (OperatorDecision, error) {
+func (fakeChannel) SendForApproval(context.Context, string, []int64) (OperatorDecision, error) {
 	return OperatorDecision{Action: "skip"}, nil
 }
-func (fakeChannel) SendForQuorumApproval(context.Context, string, int) (QuorumDecision, error) {
+func (fakeChannel) SendForQuorumApproval(context.Context, string, int, []int64) (QuorumDecision, error) {
 	return QuorumDecision{Action: "skip"}, nil
 }
 

--- a/runs_cmd.go
+++ b/runs_cmd.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/renezander030/draftcat/internal/config"
+	statestore "github.com/renezander030/draftcat/internal/state"
+)
+
+// `draftcat runs` — read the audit trail back out.
+//
+// Every run and every approval decision has been recorded in SQLite for a
+// while, but nothing could read it without an sqlite3 client. An audit trail
+// you cannot query is only half an audit trail, which is what issue #4 was
+// actually asking for ("easy to review, search, and archive").
+//
+// It asked for a JSON file per run under logs/. That would duplicate state.db
+// into a second, unindexed copy and add a retention problem, so this exposes
+// the existing store instead: `--json` gives the same archivable output on
+// stdout, pipeable into a file, jq, or a log shipper.
+//
+// Per-step timings and token counts are NOT here: those live in the
+// observability spans (`observability.spans`, OTLP/Prometheus), which is the
+// right home for them. This is the durable governance record — what ran, what
+// was decided, by whom.
+
+type runJSON struct {
+	Pipeline  string         `json:"pipeline"`
+	StartedAt string         `json:"started_at"`
+	EndedAt   string         `json:"ended_at"`
+	Duration  float64        `json:"duration_seconds"`
+	Status    string         `json:"status"`
+	Error     string         `json:"error,omitempty"`
+	Approvals []approvalJSON `json:"approvals"`
+}
+
+type approvalJSON struct {
+	Step       string `json:"step"`
+	DecidedAt  string `json:"decided_at"`
+	Decision   string `json:"decision"`
+	OperatorID int64  `json:"operator_id"`
+	QuorumN    int    `json:"quorum_n"`
+	QuorumGot  int    `json:"quorum_got"`
+	Signed     bool   `json:"signed"`
+}
+
+func runRunsCmd(args []string) int {
+	pipeline := ""
+	configPath := "config.yaml"
+	limit := 20
+	jsonOut := false
+
+	for i := 0; i < len(args); i++ {
+		switch a := args[i]; a {
+		case "-json", "--json":
+			jsonOut = true
+		case "-limit", "--limit":
+			if i+1 >= len(args) {
+				fmt.Fprintln(os.Stderr, "runs: --limit requires a number")
+				return 2
+			}
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n <= 0 {
+				fmt.Fprintf(os.Stderr, "runs: --limit must be a positive integer, got %q\n", args[i+1])
+				return 2
+			}
+			limit = n
+			i++
+		case "-config", "--config":
+			if i+1 >= len(args) {
+				fmt.Fprintln(os.Stderr, "runs: --config requires a path")
+				return 2
+			}
+			configPath = args[i+1]
+			i++
+		case "-h", "--help", "help":
+			fmt.Println("Usage: draftcat runs [pipeline] [--limit N] [--json] [--config path]")
+			fmt.Println("\nShows recent pipeline runs and the approval decisions recorded during each.")
+			fmt.Println("Omit the pipeline name to see every pipeline. --json prints the archivable form.")
+			return 0
+		default:
+			if strings.HasPrefix(a, "-") {
+				fmt.Fprintf(os.Stderr, "runs: unknown option %q\n", a)
+				return 2
+			}
+			if pipeline != "" {
+				fmt.Fprintf(os.Stderr, "runs: unexpected argument %q\n", a)
+				return 2
+			}
+			pipeline = a
+		}
+	}
+
+	st, closeStore, code := openStateForCmd(configPath)
+	if code != 0 {
+		return code
+	}
+	defer closeStore()
+
+	var runs []statestore.RunRecord
+	var err error
+	if pipeline == "" {
+		runs, err = st.AllRecentRuns(limit)
+	} else {
+		runs, err = st.RecentRuns(pipeline, limit)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "runs: read run history: %v\n", err)
+		return 1
+	}
+
+	out := make([]runJSON, 0, len(runs))
+	for _, r := range runs {
+		out = append(out, runJSON{
+			Pipeline:  r.Pipeline,
+			StartedAt: r.StartedAt.Format(time.RFC3339),
+			EndedAt:   r.EndedAt.Format(time.RFC3339),
+			Duration:  r.EndedAt.Sub(r.StartedAt).Seconds(),
+			Status:    r.Status,
+			Error:     r.Error,
+			Approvals: approvalsDuring(st, r),
+		})
+	}
+
+	if jsonOut {
+		b, mErr := json.MarshalIndent(out, "", "  ")
+		if mErr != nil {
+			fmt.Fprintf(os.Stderr, "runs: encode: %v\n", mErr)
+			return 1
+		}
+		fmt.Println(string(b))
+		return 0
+	}
+
+	if len(out) == 0 {
+		if pipeline == "" {
+			fmt.Println("No runs recorded yet.")
+		} else {
+			fmt.Printf("No runs recorded for %q.\n", pipeline)
+		}
+		return 0
+	}
+	for _, r := range out {
+		line := fmt.Sprintf("%s  %-22s %-7s %6.1fs", r.StartedAt, r.Pipeline, r.Status, r.Duration)
+		if r.Error != "" {
+			line += "  " + truncateOneLine(r.Error, 60)
+		}
+		fmt.Println(line)
+		for _, a := range r.Approvals {
+			who := "system"
+			if a.OperatorID != 0 {
+				who = strconv.FormatInt(a.OperatorID, 10)
+			}
+			receipt := ""
+			if a.Signed {
+				receipt = " [signed]"
+			}
+			fmt.Printf("    %-20s %-11s by %s (%d/%d)%s\n",
+				a.Step, a.Decision, who, a.QuorumGot, a.QuorumN, receipt)
+		}
+	}
+	return 0
+}
+
+// approvalsDuring attaches the approval decisions recorded inside a run's
+// window. There is no run_id on action_approvals, but the scheduler refuses to
+// start a pipeline that is already running, so runs of one pipeline never
+// overlap and the timestamp window is an unambiguous join.
+func approvalsDuring(st *statestore.StateStore, r statestore.RunRecord) []approvalJSON {
+	recs, err := st.ApprovalsForPipeline(r.Pipeline, 1000)
+	if err != nil {
+		return nil
+	}
+	var out []approvalJSON
+	for _, a := range recs {
+		if a.DecidedAt.Before(r.StartedAt) || a.DecidedAt.After(r.EndedAt) {
+			continue
+		}
+		out = append(out, approvalJSON{
+			Step:       a.Step,
+			DecidedAt:  a.DecidedAt.Format(time.RFC3339),
+			Decision:   a.Decision,
+			OperatorID: a.OperatorID,
+			QuorumN:    a.QuorumN,
+			QuorumGot:  a.QuorumGot,
+			Signed:     a.Signature != "",
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].DecidedAt < out[j].DecidedAt })
+	return out
+}
+
+// openStateForCmd resolves the state path exactly like the engine does — env
+// override, then config, then ./state.db — and opens it read-only enough for a
+// reporting command.
+func openStateForCmd(configPath string) (*statestore.StateStore, func(), int) {
+	statePath := strings.TrimSpace(os.Getenv("DRAFTCAT_STATE_PATH"))
+	if statePath == "" {
+		// #nosec G304 -- configPath is the operator's own --config argument on
+		// their own machine; reading the file they named is the feature. Same
+		// pattern as runAuditVerify.
+		if data, err := os.ReadFile(configPath); err == nil {
+			var cfg config.Config
+			if yaml.Unmarshal(data, &cfg) == nil {
+				statePath = cfg.State.Path
+			}
+		}
+	}
+	if statePath == "" {
+		statePath = "./state.db"
+	}
+	st, err := statestore.OpenStateStore(statePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "runs: open state store %s: %v\n", statePath, err)
+		return nil, func() {}, 1
+	}
+	return st, func() { _ = st.Close() }, 0
+}

--- a/runs_cmd_test.go
+++ b/runs_cmd_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	statestore "github.com/renezander030/draftcat/internal/state"
+)
+
+// approvalsDuring joins approval decisions onto the run they happened in by
+// timestamp window. There is no run_id column, so this join is the whole
+// correctness question for `draftcat runs`.
+
+func TestApprovalsDuring_AttachesOnlyDecisionsInsideTheWindow(t *testing.T) {
+	st := newTempStateStore(t)
+
+	start := time.Now().Add(-10 * time.Minute)
+	end := start.Add(5 * time.Minute)
+
+	// Inside the window.
+	if err := st.RecordApproval("p", "gate", start.Add(time.Minute), "approve", 111, "h1", 1, 1, "", ""); err != nil {
+		t.Fatalf("RecordApproval inside: %v", err)
+	}
+	// Before the run started, and after it ended — both must be excluded.
+	if err := st.RecordApproval("p", "old", start.Add(-time.Hour), "approve", 111, "h0", 1, 1, "", ""); err != nil {
+		t.Fatalf("RecordApproval before: %v", err)
+	}
+	if err := st.RecordApproval("p", "later", end.Add(time.Hour), "skip", 222, "h2", 1, 0, "", ""); err != nil {
+		t.Fatalf("RecordApproval after: %v", err)
+	}
+
+	got := approvalsDuring(st, statestore.RunRecord{
+		Pipeline: "p", StartedAt: start, EndedAt: end, Status: "ok",
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %d approval(s) in window, want 1: %+v", len(got), got)
+	}
+	if got[0].Step != "gate" {
+		t.Errorf("step = %q, want gate", got[0].Step)
+	}
+	if got[0].Decision != "approve" || got[0].OperatorID != 111 {
+		t.Errorf("decision/operator = %s/%d, want approve/111", got[0].Decision, got[0].OperatorID)
+	}
+}
+
+// A run of a different pipeline must never pick up this one's approvals.
+func TestApprovalsDuring_ScopedToPipeline(t *testing.T) {
+	st := newTempStateStore(t)
+	start := time.Now().Add(-time.Minute)
+	end := time.Now()
+
+	if err := st.RecordApproval("other", "gate", start.Add(time.Second), "approve", 1, "h", 1, 1, "", ""); err != nil {
+		t.Fatalf("RecordApproval: %v", err)
+	}
+	got := approvalsDuring(st, statestore.RunRecord{Pipeline: "p", StartedAt: start, EndedAt: end})
+	if len(got) != 0 {
+		t.Fatalf("got %d approval(s) from another pipeline, want 0", len(got))
+	}
+}
+
+// The signed flag drives a "[signed]" marker in the human output, so it must
+// reflect whether a receipt was actually stored.
+func TestApprovalsDuring_ReportsSignedReceipts(t *testing.T) {
+	st := newTempStateStore(t)
+	start := time.Now().Add(-time.Minute)
+	end := time.Now()
+
+	if err := st.RecordApproval("p", "signed-step", start.Add(time.Second), "approve", 1, "h", 1, 1, "nonce", "sig"); err != nil {
+		t.Fatalf("RecordApproval: %v", err)
+	}
+	if err := st.RecordApproval("p", "plain-step", start.Add(2*time.Second), "approve", 1, "h", 1, 1, "", ""); err != nil {
+		t.Fatalf("RecordApproval: %v", err)
+	}
+
+	got := approvalsDuring(st, statestore.RunRecord{Pipeline: "p", StartedAt: start, EndedAt: end})
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2", len(got))
+	}
+	signed := map[string]bool{}
+	for _, a := range got {
+		signed[a.Step] = a.Signed
+	}
+	if !signed["signed-step"] {
+		t.Error("a row with a signature must report signed=true")
+	}
+	if signed["plain-step"] {
+		t.Error("a row with no signature must report signed=false")
+	}
+}
+
+// Ordering matters for reading a gate's history back: oldest decision first.
+func TestApprovalsDuring_SortedOldestFirst(t *testing.T) {
+	st := newTempStateStore(t)
+	start := time.Now().Add(-time.Hour)
+	end := time.Now()
+
+	_ = st.RecordApproval("p", "third", start.Add(30*time.Minute), "approve", 1, "h", 1, 1, "", "")
+	_ = st.RecordApproval("p", "first", start.Add(time.Minute), "adjust", 1, "h", 1, 0, "", "")
+	_ = st.RecordApproval("p", "second", start.Add(10*time.Minute), "adjust", 1, "h", 1, 0, "", "")
+
+	got := approvalsDuring(st, statestore.RunRecord{Pipeline: "p", StartedAt: start, EndedAt: end})
+	if len(got) != 3 {
+		t.Fatalf("got %d, want 3", len(got))
+	}
+	want := []string{"first", "second", "third"}
+	for i, w := range want {
+		if got[i].Step != w {
+			t.Errorf("position %d = %q, want %q", i, got[i].Step, w)
+		}
+	}
+}
+
+func TestAllRecentRuns_NewestFirstAcrossPipelines(t *testing.T) {
+	st := newTempStateStore(t)
+	base := time.Now().Add(-time.Hour)
+
+	if err := st.RecordRun("alpha", base, base.Add(time.Minute), nil); err != nil {
+		t.Fatalf("RecordRun alpha: %v", err)
+	}
+	if err := st.RecordRun("beta", base.Add(10*time.Minute), base.Add(11*time.Minute), errors.New("boom")); err != nil {
+		t.Fatalf("RecordRun beta: %v", err)
+	}
+
+	runs, err := st.AllRecentRuns(10)
+	if err != nil {
+		t.Fatalf("AllRecentRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("got %d run(s), want 2", len(runs))
+	}
+	if runs[0].Pipeline != "beta" {
+		t.Errorf("newest run = %q, want beta", runs[0].Pipeline)
+	}
+	if runs[0].Status == "ok" {
+		t.Errorf("a run recorded with an error should not be status ok, got %q", runs[0].Status)
+	}
+}
+
+func TestAllRecentRuns_RespectsLimit(t *testing.T) {
+	st := newTempStateStore(t)
+	base := time.Now().Add(-time.Hour)
+	for i := 0; i < 5; i++ {
+		_ = st.RecordRun("p", base.Add(time.Duration(i)*time.Minute), base.Add(time.Duration(i)*time.Minute+time.Second), nil)
+	}
+	runs, err := st.AllRecentRuns(3)
+	if err != nil {
+		t.Fatalf("AllRecentRuns: %v", err)
+	}
+	if len(runs) != 3 {
+		t.Fatalf("got %d, want 3 (limit ignored)", len(runs))
+	}
+}
+
+func TestAllRecentRuns_NilStoreIsSafe(t *testing.T) {
+	var s *statestore.StateStore
+	runs, err := s.AllRecentRuns(10)
+	if err != nil || len(runs) != 0 {
+		t.Fatalf("nil store = (%v, %v), want (empty, nil)", runs, err)
+	}
+}

--- a/test_cmd.go
+++ b/test_cmd.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/renezander030/draftcat/internal/config"
-	skillsapi "github.com/renezander030/draftcat/internal/skills"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/renezander030/draftcat/internal/channels"
+	"github.com/renezander030/draftcat/internal/config"
+	skillsapi "github.com/renezander030/draftcat/internal/skills"
 )
 
 // stubChannel is the in-memory OperatorChannel used by `draftcat test`.
@@ -29,7 +31,29 @@ func (s *stubChannel) Send(text string) error {
 	return nil
 }
 
-func (s *stubChannel) SendForApproval(ctx context.Context, draft string) (OperatorDecision, error) {
+// Name reports the channel a fixture run stands in for. `draftcat test` is a
+// dry run, so it answers with the real channel name to keep a step's
+// `channel:` routing check behaving exactly as it would in production.
+func (s *stubChannel) Name() string { return channels.Telegram }
+
+// SendForQuorumApproval collapses an N-of-M gate to a single fixture decision.
+// A dry run has no second human to ask, so quorum is exercised for routing and
+// config correctness here, not for its multi-operator semantics — those are
+// covered by quorumReducer's unit tests.
+func (s *stubChannel) SendForQuorumApproval(ctx context.Context, draft string, need int, approvers []int64) (QuorumDecision, error) {
+	fmt.Printf("  [approval-quorum] need=%d distinct approver(s)\n", need)
+	d, err := s.SendForApproval(ctx, draft, approvers)
+	if err != nil {
+		return QuorumDecision{Action: "timeout"}, err
+	}
+	qd := QuorumDecision{Action: d.Action, Text: d.Text}
+	if d.Action == "approve" && d.ApproverID != 0 {
+		qd.Approvers = []int64{d.ApproverID}
+	}
+	return qd, nil
+}
+
+func (s *stubChannel) SendForApproval(ctx context.Context, draft string, approvers []int64) (OperatorDecision, error) {
 	fmt.Printf("  [approval-draft]\n%s\n", indentBlock(draft, "    "))
 	if s.idx < len(s.decisions) {
 		d := s.decisions[s.idx]
@@ -267,7 +291,7 @@ func runTestPipeline(cfg *config.Config, p config.PipelineConfig, skills *skills
 			}
 			aiOutput := data["ai_output"]
 			draftMsg := fmt.Sprintf("[test] draft:\n\n%v", aiOutput)
-			decision, _ := ch.SendForApproval(context.Background(), draftMsg)
+			decision, _ := ch.SendForApproval(context.Background(), draftMsg, nil)
 			if decision.Action == "skip" {
 				fmt.Println("  [stop] operator skipped — pipeline ends")
 				return 0

--- a/webhook_signature_test.go
+++ b/webhook_signature_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	statestore "github.com/renezander030/draftcat/internal/state"
+)
+
+// The inbound webhook STARTS a pipeline, so an attacker who can replay or
+// tamper with a request can make draftcat act. A bearer token alone proves only
+// that the caller once saw the token; these tests pin the body-and-time binding
+// that closes that.
+
+// newTempStateStore opens a throwaway SQLite store for tests that need the
+// replay guard (which lives in seen_items).
+func newTempStateStore(t *testing.T) *statestore.StateStore {
+	t.Helper()
+	s, err := statestore.OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open temp state store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func signBody(secret []byte, ts int64, body []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(strconv.FormatInt(ts, 10)))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	return fmt.Sprintf("t=%d,v1=%s", ts, hex.EncodeToString(mac.Sum(nil)))
+}
+
+func TestVerifyWebhookSignature_ValidSignaturePasses(t *testing.T) {
+	secret := []byte("s3cret")
+	body := []byte(`{"lead":"acme"}`)
+	now := time.Now()
+
+	err := verifyWebhookSignature(signBody(secret, now.Unix(), body), body, secret, 300, now)
+	if err != nil {
+		t.Fatalf("valid signature rejected: %v", err)
+	}
+}
+
+// The whole point of signing the body: a swapped payload must not verify.
+func TestVerifyWebhookSignature_TamperedBodyFails(t *testing.T) {
+	secret := []byte("s3cret")
+	now := time.Now()
+	header := signBody(secret, now.Unix(), []byte(`{"amount":10}`))
+
+	err := verifyWebhookSignature(header, []byte(`{"amount":100000}`), secret, 300, now)
+	if err == nil {
+		t.Fatal("a body swapped after signing must fail verification")
+	}
+}
+
+func TestVerifyWebhookSignature_WrongSecretFails(t *testing.T) {
+	now := time.Now()
+	body := []byte("x")
+	header := signBody([]byte("attacker-guess"), now.Unix(), body)
+
+	if err := verifyWebhookSignature(header, body, []byte("real-secret"), 300, now); err == nil {
+		t.Fatal("signature made with the wrong secret must fail")
+	}
+}
+
+// Bounding the clock skew is what stops an old captured request being re-fired
+// indefinitely.
+func TestVerifyWebhookSignature_StaleTimestampFails(t *testing.T) {
+	secret := []byte("s3cret")
+	body := []byte("x")
+	now := time.Now()
+	old := now.Add(-30 * time.Minute).Unix()
+
+	err := verifyWebhookSignature(signBody(secret, old, body), body, secret, 300, now)
+	if err == nil {
+		t.Fatal("a 30-minute-old signature must fail a 5-minute window")
+	}
+	if !strings.Contains(err.Error(), "window") {
+		t.Errorf("error %q should explain the skew window", err)
+	}
+}
+
+// A clock ahead of ours is equally suspect — the window is two-sided.
+func TestVerifyWebhookSignature_FutureTimestampFails(t *testing.T) {
+	secret := []byte("s3cret")
+	body := []byte("x")
+	now := time.Now()
+	future := now.Add(30 * time.Minute).Unix()
+
+	if err := verifyWebhookSignature(signBody(secret, future, body), body, secret, 300, now); err == nil {
+		t.Fatal("a far-future signature must fail the skew window")
+	}
+}
+
+func TestVerifyWebhookSignature_MissingHeaderFails(t *testing.T) {
+	if err := verifyWebhookSignature("", []byte("x"), []byte("s"), 300, time.Now()); err == nil {
+		t.Fatal("absent signature header must fail when a signature is demanded")
+	}
+}
+
+func TestVerifyWebhookSignature_MalformedHeaderFails(t *testing.T) {
+	now := time.Now()
+	for _, h := range []string{
+		"garbage",
+		"t=123",               // no v1
+		"v1=abc",              // no t
+		"t=notanumber,v1=abc", // unparseable timestamp
+		fmt.Sprintf("t=%d", now.Unix()),
+	} {
+		if err := verifyWebhookSignature(h, []byte("x"), []byte("s"), 300, now); err == nil {
+			t.Errorf("malformed header %q must fail", h)
+		}
+	}
+}
+
+// A signature is spent once. Within the skew window a valid signature would
+// otherwise stay replayable, so the second presentation must be refused.
+// (Uses the package-level state store, which the handler also consults.)
+func TestVerifyWebhookSignature_ReplayIsRejected(t *testing.T) {
+	prev := state
+	state = newTempStateStore(t)
+	t.Cleanup(func() { state = prev })
+
+	secret := []byte("s3cret")
+	body := []byte(`{"a":1}`)
+	now := time.Now()
+	header := signBody(secret, now.Unix(), body)
+
+	if err := verifyWebhookSignature(header, body, secret, 300, now); err != nil {
+		t.Fatalf("first use of a valid signature must pass: %v", err)
+	}
+	err := verifyWebhookSignature(header, body, secret, 300, now)
+	if err == nil {
+		t.Fatal("replaying the same signature must be rejected")
+	}
+	if !strings.Contains(err.Error(), "replay") {
+		t.Errorf("error %q should name the replay", err)
+	}
+}
+
+// Without a state store the signature still authenticates — we just cannot
+// promise single-use. Verify that path does not error.
+func TestVerifyWebhookSignature_NoStateStoreStillVerifies(t *testing.T) {
+	prev := state
+	state = nil
+	t.Cleanup(func() { state = prev })
+
+	secret := []byte("s3cret")
+	body := []byte("x")
+	now := time.Now()
+
+	if err := verifyWebhookSignature(signBody(secret, now.Unix(), body), body, secret, 300, now); err != nil {
+		t.Fatalf("signature check must work without a state store: %v", err)
+	}
+}


### PR DESCRIPTION
Six governance gaps, found by mining recurring pains across humanlayer, n8n, dagu, dify, langfuse, litellm and agentgateway, then checked against what draftcat already ships. Common theme: **the gate must hold when things go wrong** — restart, misconfig, replay, overspend, wrong approver, wrong channel.

Where nothing is configured, behavior is unchanged: no cost keys, no `approvers`, and no signature header all mean today's semantics.

## What's in here

**1. Durable approval gates** — `pending_approvals` + `reconcileInterruptedApprovals`

A gate lived only in an in-process poll loop: the draft went out, the engine blocked on a ticker, and `action_approvals` was written only once a decision arrived. A redeploy or crash mid-approval left **no trace at all** — the operator saw a live-looking message with buttons attached to a run that no longer existed, and `UnapprovedActions` couldn't see the hole either.

A row is now written *before* the draft is sent, resolved on any terminal decision, and reconciled to `interrupted` on the next boot: an audit row so the compliance queries count it, plus a message telling the operator the action did **not** run.

Deliberately **not** resuming the run — the in-memory data context is gone after a crash. A gate whose outcome is unknown is never treated as an approval.

**2. Cost caps in money** — `budgets.per_day_cost` / `per_pipeline_cost`

Per-call cost was already computed from the model rates and thrown away. It now accumulates and blocks. The check sits inside `check()`, which already guards every LLM call, so a call site added later can't spend uncapped by forgetting to wire it.

Enforced *between* calls — a pre-call estimate needs the response token count, which doesn't exist yet — so one in-flight call may overshoot by at most a step. Documented; bound it with `per_step_tokens`. `0` = off.

**3. Per-operator approver scoping** — `steps[].approvers`

`allowed_users` was one flat list and quorum only a count, so whoever could approve an inbox draft could also release an invoice. Quorum says *how many*; this says *which ones*. It intersects with `allowed_users` and **never widens**, so a step can't grant rights to someone the channel doesn't already trust.

**4. `channel: slack` validated OK but was never implemented**

The validator's allow-list carried `slack` while no Slack channel existed and `step.Channel` was never read at runtime — so approvals silently went to Telegram. A gate routing somewhere the operator isn't watching is worse than no gate, because it still looks like it held.

`internal/channels` is now the single list both the validator and the engine read. Unimplemented channel = hard error; the engine also rejects a step naming a channel it isn't running. The honest fix was deleting the phantom entry, not building Slack. The README's "Telegram / Slack" claim was wrong too, and is corrected.

**5. Body-bound webhook signatures** — `webhook.require_signature`

A bearer token proves only that the caller once saw it: the body isn't bound and a captured header replays forever — and this endpoint **starts pipelines**. Adds `X-Draftcat-Signature: t=<unix>,v1=<hmac-sha256(t + "." + body)>`, a skew window, and single-use signatures via the existing dedup table.

Verified whenever present (so a broken signer fails loudly), demanded when `require_signature: true`. Bearer auth is unchanged and still required. The existing constant-time compare and body size limit were already good.

**6. Config validation on the boot path** — `validate.CheckAtStartup`

The validator was thorough but opt-in, so a bad config booted fine and failed hours later mid-pipeline. Errors are now fatal at startup, warnings logged. `DRAFTCAT_SKIP_VALIDATE=1` overrides. Shares one check body with `draftcat validate` so the two can't drift.

## Verification

44 new tests. Build, `go vet`, `gofmt`, full suite, `go run . validate`, and `golangci-lint --new-from-rev` all pass; **no new lint issues** against the 139-issue baseline. Both commits build and test independently.

The three security-critical fixes were **mutation-checked** — each was deliberately broken to confirm the test actually bites:

| Mutation | Result |
|---|---|
| Re-add phantom `slack` to the registry | channel test fails |
| Let `approvers` widen past `allowed_users` | *"privilege escalation"* test fails |
| Remove the webhook replay guard | replay test fails |

End-to-end against the built binary: a bad config **refuses to boot** (exit 1, names the offending step), the escape hatch overrides, `draftcat test` is unchanged, and a simulated crashed gate reconciled correctly — `pending`→0, `interrupted`→1, audit row written, and `UnapprovedActions` now sees it.

## Review notes

- `main.go` carries four of the six changes, which is why this is one feature commit rather than six — splitting it would have produced non-building intermediates.
- New config keys are all additive and default to off.
- `internal/channels` exists specifically so the validator and engine can't drift again; adding a name there without an implementation reintroduces the bug.
